### PR TITLE
Bootstrap server, DB migrations, health endpoint, and basic health test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+PORT=3000
+DATABASE_URL=postgres://triarch:triarch@localhost:5432/triarch
+SKIP_DB=false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: install dev build start migrate seed test
+
+install:
+	npm install
+
+dev:
+	npm run dev
+
+build:
+	npm run build
+
+start:
+	npm run start
+
+migrate:
+	npm run migrate
+
+seed:
+	npm run seed
+
+test:
+	npm run test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16
+    container_name: triarch_postgres
+    environment:
+      POSTGRES_USER: triarch
+      POSTGRES_PASSWORD: triarch
+      POSTGRES_DB: triarch
+    ports:
+      - "5432:5432"
+    volumes:
+      - triarch_db:/var/lib/postgresql/data
+volumes:
+  triarch_db:

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS app_config (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "triarch-shattered-realms",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
+    "build": "tsc -p tsconfig.json",
+    "migrate": "tsx scripts/migrate.ts",
+    "seed": "tsx scripts/seed.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "pg": "^8.12.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.8",
+    "@types/supertest": "^2.0.16",
+    "supertest": "^6.3.4",
+    "tsx": "^4.15.6",
+    "typescript": "^5.5.2",
+    "vitest": "^2.0.5"
+  }
+}

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfig } from "../src/config";
+import { Database } from "../src/db";
+
+const migrationsDir = path.resolve(__dirname, "..", "migrations");
+
+const run = async () => {
+  const config = loadConfig();
+  if (config.SKIP_DB) {
+    throw new Error("Cannot run migrations when SKIP_DB=true.");
+  }
+
+  const db = new Database(config.DATABASE_URL, false);
+  const pool = db.getPool();
+
+  await pool.query(
+    "CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY, run_at TIMESTAMPTZ NOT NULL DEFAULT NOW())"
+  );
+
+  const files = fs
+    .readdirSync(migrationsDir)
+    .filter((file) => file.endsWith(".sql"))
+    .sort();
+
+  for (const file of files) {
+    const id = file;
+    const existing = await pool.query(
+      "SELECT id FROM schema_migrations WHERE id = $1",
+      [id]
+    );
+    if (existing.rowCount && existing.rowCount > 0) {
+      continue;
+    }
+
+    const sql = fs.readFileSync(path.join(migrationsDir, file), "utf-8");
+    await pool.query("BEGIN");
+    try {
+      await pool.query(sql);
+      await pool.query("INSERT INTO schema_migrations (id) VALUES ($1)", [id]);
+      await pool.query("COMMIT");
+      console.log(`Applied migration: ${file}`);
+    } catch (error) {
+      await pool.query("ROLLBACK");
+      throw error;
+    }
+  }
+
+  await db.close();
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,24 @@
+import { loadConfig } from "../src/config";
+import { Database } from "../src/db";
+
+const run = async () => {
+  const config = loadConfig();
+  if (config.SKIP_DB) {
+    throw new Error("Cannot seed when SKIP_DB=true.");
+  }
+
+  const db = new Database(config.DATABASE_URL, false);
+  const pool = db.getPool();
+
+  await pool.query(
+    "INSERT INTO app_config (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+    ["world_name", "Triarch: Shattered Realms"]
+  );
+
+  await db.close();
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,19 @@
+import express from "express";
+import { Database } from "./db";
+
+export const createApp = (db: Database) => {
+  const app = express();
+  app.use(express.json());
+
+  app.get("/health", async (_req, res) => {
+    const dbStatus = await db.connect();
+    const ok = dbStatus === "ok" || dbStatus === "skipped";
+
+    res.status(ok ? 200 : 503).json({
+      status: ok ? "ok" : "degraded",
+      db: dbStatus,
+    });
+  });
+
+  return app;
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  PORT: z.coerce.number().int().positive().default(3000),
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  SKIP_DB: z
+    .string()
+    .optional()
+    .transform((value) => value === "true"),
+});
+
+export type AppConfig = z.infer<typeof envSchema>;
+
+export const loadConfig = (): AppConfig => {
+  const parsed = envSchema.safeParse(process.env);
+  if (!parsed.success) {
+    const formatted = parsed.error.flatten().fieldErrors;
+    const message = `Invalid environment configuration: ${JSON.stringify(
+      formatted
+    )}`;
+    throw new Error(message);
+  }
+
+  return parsed.data;
+};

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,42 @@
+import { Pool } from "pg";
+
+export type DatabaseStatus = "ok" | "skipped" | "error";
+
+export class Database {
+  private pool: Pool | null;
+
+  constructor(private readonly databaseUrl: string, private readonly skip: boolean) {
+    this.pool = this.skip ? null : new Pool({ connectionString: databaseUrl });
+  }
+
+  async connect(): Promise<DatabaseStatus> {
+    if (!this.pool) {
+      return "skipped";
+    }
+
+    try {
+      const client = await this.pool.connect();
+      await client.query("SELECT 1");
+      client.release();
+      return "ok";
+    } catch (error) {
+      return "error";
+    }
+  }
+
+  getPool(): Pool {
+    if (!this.pool) {
+      throw new Error("Database is disabled. Set SKIP_DB=false to enable.");
+    }
+
+    return this.pool;
+  }
+
+  async close(): Promise<void> {
+    if (!this.pool) {
+      return;
+    }
+
+    await this.pool.end();
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,21 @@
+import { loadConfig } from "./config";
+import { Database } from "./db";
+import { createApp } from "./app";
+
+const config = loadConfig();
+const db = new Database(config.DATABASE_URL, config.SKIP_DB ?? false);
+const app = createApp(db);
+
+const server = app.listen(config.PORT, () => {
+  console.log(`Triarch server listening on :${config.PORT}`);
+});
+
+const shutdown = async () => {
+  server.close(async () => {
+    await db.close();
+    process.exit(0);
+  });
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,0 +1,27 @@
+import request from "supertest";
+import { describe, expect, it, beforeEach } from "vitest";
+import { Database } from "../src/db";
+import { createApp } from "../src/app";
+
+const buildApp = () => {
+  const db = new Database("postgres://example", true);
+  return createApp(db);
+};
+
+describe("GET /health", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  it("returns ok when database is skipped", async () => {
+    const response = await request(app).get("/health");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: "ok",
+      db: "skipped",
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "scripts", "tests"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
### Motivation
- Provide minimal server scaffolding and a health check to start the iterative vertical-slice development.
- Add Postgres wiring, migrations, and seeding so local persistent data and schema management are available.
- Include developer tooling and runtime configuration for reproducible local development and onboarding.
- Add a simple automated test to validate the health endpoint behavior when the database is intentionally skipped.

### Description
- Add an Express-based application with `GET /health`, server startup in `src/server.ts`, and a `Database` helper in `src/db.ts` that supports `SKIP_DB` semantics and basic connectivity checks.
- Introduce migration runner `scripts/migrate.ts`, seed script `scripts/seed.ts`, and initial migration `migrations/001_init.sql` to create the `app_config` table.
- Add project configuration and dev tooling including `package.json`, `tsconfig.json`, `docker-compose.yml`, `.env.example`, and `Makefile` for common workflows.
- Add a unit test `tests/health.test.ts` using `vitest` and `supertest` that asserts `/health` returns `{status: "ok", db: "skipped"}` when the DB is disabled.

### Testing
- An automated unit test `tests/health.test.ts` was added to assert `GET /health` returns success when the database is skipped.
- Tests were not executed in this rollout; run them locally with `npm run test` (or `vitest run`) after installing dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be7c8e52c83249d9f35ec41dba369)