### PR TITLE
Add Unity playtest client, browser Playtest Console, and server playtest gameplay routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ For comprehensive design documentation, see:
 - [Gameplay Overview](docs/GAMEPLAY_OVERVIEW.md) - Full game design theory and mechanics
 - [API Documentation](docs/API.md) - RESTful API endpoints and usage
 - [Authentication Stub](design/authentication.md) - Initial player auth flow
+- [Combat Slice](design/combat.md) - PvE combat and cooldown rules
+- [Death & Loot](design/death_loot.md) - Zone-tier loot drops
+- [Betrayal Questline](design/betrayal.md) - Faction switching flow
+- [Unity Playtest Client](design/client_playtest.md) - Minimal engine client notes
 
 ## Getting Started
 
@@ -52,6 +56,27 @@ npm run build
 npm start
 ```
 
+### Playtest Console (Minimal UI)
+
+Open the playtest UI in a browser after the server starts:
+
+```
+http://localhost:3000
+```
+
+The UI lets you register/login, create a character, enter a zone, gather, fight NPCs, loot, and run the betrayal questline.
+
+### Unity Playtest Client
+
+A minimal Unity client lives in `client/unity` and renders a basic animated character + NPC with buttons for login, character creation, zone entry, and combat.
+
+```bash
+# Open in Unity Hub
+open client/unity
+```
+
+See `client/unity/README.md` for setup steps.
+
 ### Auth Stub Quickstart
 
 ```bash
@@ -66,10 +91,24 @@ curl -X POST http://localhost:3000/api/auth/login \
   -d '{"email":"player@example.com","password":"securepassword"}'
 ```
 
-Use the returned `token` as a bearer token for session validation:
+Use the returned `token` as a bearer token for authenticated routes:
 
 ```bash
 curl http://localhost:3000/api/auth/me -H "Authorization: Bearer <token>"
+```
+
+### Characters Quickstart
+
+```bash
+# Create a character (requires auth)
+curl -X POST http://localhost:3000/api/characters \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"name":"PlayerOne","faction_id":1,"class_id":1}'
+
+# List your characters
+curl http://localhost:3000/api/characters \
+  -H "Authorization: Bearer <token>"
 ```
 
 ### World Quickstart
@@ -78,10 +117,12 @@ curl http://localhost:3000/api/auth/me -H "Authorization: Bearer <token>"
 # Enter a zone and set a character position
 curl -X POST http://localhost:3000/api/world/zone-enter \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
   -d '{"character_id":1,"zone_id":2,"position":{"x":120.5,"y":88.25}}'
 
 # Fetch the current world state for a character
-curl http://localhost:3000/api/world/state/1
+curl http://localhost:3000/api/world/state/1 \
+  -H "Authorization: Bearer <token>"
 ```
 
 ### Inventory Quickstart
@@ -90,27 +131,86 @@ curl http://localhost:3000/api/world/state/1
 # Add items to a character inventory
 curl -X POST http://localhost:3000/api/inventory/1/add \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
   -d '{"item_code":"IRON_ORE","quantity":5}'
 
 # Remove items from a character inventory
 curl -X POST http://localhost:3000/api/inventory/1/remove \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
   -d '{"item_code":"IRON_ORE","quantity":2}'
 
 # Fetch inventory
-curl http://localhost:3000/api/inventory/1
+curl http://localhost:3000/api/inventory/1 \
+  -H "Authorization: Bearer <token>"
 ```
 
 ### Gathering Quickstart
 
 ```bash
 # List gathering nodes in a zone
-curl http://localhost:3000/api/gathering/nodes/1
+curl http://localhost:3000/api/gathering/nodes/1 \
+  -H "Authorization: Bearer <token>"
 
 # Attempt to gather from a node
 curl -X POST http://localhost:3000/api/gathering/attempt \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
   -d '{"character_id":1,"node_code":"COPPER_VEIN","client_position":{"x":112.0,"y":92.0}}'
+```
+
+### Combat Quickstart
+
+```bash
+# List NPCs in a zone
+curl http://localhost:3000/api/combat/npcs/1 \
+  -H "Authorization: Bearer <token>"
+
+# Attack an NPC
+curl -X POST http://localhost:3000/api/combat/attack \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"character_id":1,"npc_id":1}'
+
+# Revive after death
+curl -X POST http://localhost:3000/api/combat/revive \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"character_id":1}'
+```
+
+### Loot Quickstart
+
+```bash
+# List loot containers in the current zone
+curl http://localhost:3000/api/loot/containers/1 \
+  -H "Authorization: Bearer <token>"
+
+# Claim a loot container
+curl -X POST http://localhost:3000/api/loot/containers/1/claim \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"character_id":1}'
+```
+
+### Betrayal Quickstart
+
+```bash
+# Start a betrayal questline
+curl -X POST http://localhost:3000/api/betrayal/start \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"character_id":1,"target_faction_id":2}'
+
+# Advance a betrayal step
+curl -X POST http://localhost:3000/api/betrayal/advance \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"character_id":1}'
+
+# Check betrayal status
+curl http://localhost:3000/api/betrayal/status/1 \
+  -H "Authorization: Bearer <token>"
 ```
 
 ### Database
@@ -132,9 +232,11 @@ npm test
 ## Project Structure
 
 ```
+├── client/            # Unity playtest client
 ├── docs/              # Design documentation
 ├── design/            # System design docs
 ├── migrations/        # Database migrations
+├── public/            # Playtest UI
 ├── scripts/           # Utility scripts
 ├── src/              # Source code
 │   ├── app.ts        # Express application

--- a/client/unity/Assets/Scripts/Playtest/ApiClient.cs
+++ b/client/unity/Assets/Scripts/Playtest/ApiClient.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections;
+using System.Text;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Triarch.Playtest
+{
+    public class ApiClient : MonoBehaviour
+    {
+        [SerializeField] private string baseUrl = "http://localhost:3000";
+        [SerializeField] private string sessionToken;
+
+        public string BaseUrl => baseUrl;
+        public string SessionToken => sessionToken;
+
+        public void SetSessionToken(string token)
+        {
+            sessionToken = token;
+        }
+
+        public IEnumerator Register(string email, string password, string displayName, Action<string> onResponse)
+        {
+            var payload = JsonUtility.ToJson(new RegisterRequest
+            {
+                email = email,
+                password = password,
+                display_name = displayName
+            });
+
+            yield return SendJson("/api/auth/register", payload, onResponse, false);
+        }
+
+        public IEnumerator Login(string email, string password, Action<AuthResponse, string> onResponse)
+        {
+            var payload = JsonUtility.ToJson(new LoginRequest
+            {
+                email = email,
+                password = password
+            });
+
+            yield return SendJson("/api/auth/login", payload, raw =>
+            {
+                if (string.IsNullOrEmpty(raw))
+                {
+                    onResponse?.Invoke(null, "Empty response");
+                    return;
+                }
+
+                try
+                {
+                    var data = JsonUtility.FromJson<AuthResponse>(raw);
+                    sessionToken = data.token;
+                    onResponse?.Invoke(data, raw);
+                }
+                catch (Exception ex)
+                {
+                    onResponse?.Invoke(null, ex.Message);
+                }
+            }, false);
+        }
+
+        public IEnumerator GetFactions(Action<string> onResponse)
+        {
+            yield return SendGet("/api/factions", onResponse, false);
+        }
+
+        public IEnumerator GetClasses(Action<string> onResponse)
+        {
+            yield return SendGet("/api/classes", onResponse, false);
+        }
+
+        public IEnumerator GetSkills(Action<string> onResponse)
+        {
+            yield return SendGet("/api/skills", onResponse, false);
+        }
+
+        public IEnumerator GetZones(Action<string> onResponse)
+        {
+            yield return SendGet("/api/zones", onResponse, false);
+        }
+
+        public IEnumerator GetCharacters(Action<string> onResponse)
+        {
+            yield return SendGet("/api/characters", onResponse, true);
+        }
+
+        public IEnumerator CreateCharacter(string name, int factionId, int classId, Action<string> onResponse)
+        {
+            var payload = JsonUtility.ToJson(new CreateCharacterRequest
+            {
+                name = name,
+                faction_id = factionId,
+                class_id = classId
+            });
+
+            yield return SendJson("/api/characters", payload, onResponse, true);
+        }
+
+        public IEnumerator AssignAbility(int characterId, int abilityId, Action<string> onResponse)
+        {
+            var payload = JsonUtility.ToJson(new AssignAbilityRequest
+            {
+                ability_id = abilityId
+            });
+
+            yield return SendJson($"/api/characters/{characterId}/abilities", payload, onResponse, true);
+        }
+
+        public IEnumerator TrainSkill(int characterId, int skillId, int experience, Action<string> onResponse)
+        {
+            var payload = JsonUtility.ToJson(new TrainSkillRequest
+            {
+                skill_id = skillId,
+                experience_gained = experience
+            });
+
+            yield return SendJson($"/api/characters/{characterId}/skills", payload, onResponse, true);
+        }
+
+        public IEnumerator EnterZone(int characterId, int zoneId, Vector2 position, Action<string> onResponse)
+        {
+            var payload = JsonUtility.ToJson(new ZoneEnterRequest
+            {
+                character_id = characterId,
+                zone_id = zoneId,
+                position = new PositionRequest { x = position.x, y = position.y }
+            });
+
+            yield return SendJson("/api/world/zone-enter", payload, onResponse, true);
+        }
+
+        public IEnumerator GetWorldState(int characterId, Action<string> onResponse)
+        {
+            yield return SendGet($"/api/world/state/{characterId}", onResponse, true);
+        }
+
+        public IEnumerator GetNpcList(int zoneId, Action<string> onResponse)
+        {
+            yield return SendGet($"/api/combat/npcs/{zoneId}", onResponse, true);
+        }
+
+        public IEnumerator AttackNpc(int characterId, int npcId, string abilityCode, Action<string> onResponse)
+        {
+            var payload = JsonUtility.ToJson(new CombatRequest
+            {
+                character_id = characterId,
+                npc_id = npcId,
+                ability_code = string.IsNullOrEmpty(abilityCode) ? null : abilityCode
+            });
+
+            yield return SendJson("/api/combat/attack", payload, onResponse, true);
+        }
+
+        private IEnumerator SendGet(string route, Action<string> onResponse, bool auth)
+        {
+            using var request = UnityWebRequest.Get(baseUrl + route);
+            if (auth && !string.IsNullOrEmpty(sessionToken))
+            {
+                request.SetRequestHeader("Authorization", $"Bearer {sessionToken}");
+            }
+            yield return request.SendWebRequest();
+            onResponse?.Invoke(request.downloadHandler.text);
+        }
+
+        private IEnumerator SendJson(string route, string payload, Action<string> onResponse, bool auth)
+        {
+            using var request = new UnityWebRequest(baseUrl + route, "POST");
+            var body = Encoding.UTF8.GetBytes(payload);
+            request.uploadHandler = new UploadHandlerRaw(body);
+            request.downloadHandler = new DownloadHandlerBuffer();
+            request.SetRequestHeader("Content-Type", "application/json");
+            if (auth && !string.IsNullOrEmpty(sessionToken))
+            {
+                request.SetRequestHeader("Authorization", $"Bearer {sessionToken}");
+            }
+
+            yield return request.SendWebRequest();
+            onResponse?.Invoke(request.downloadHandler.text);
+        }
+
+        [Serializable]
+        private class RegisterRequest
+        {
+            public string email;
+            public string password;
+            public string display_name;
+        }
+
+        [Serializable]
+        private class LoginRequest
+        {
+            public string email;
+            public string password;
+        }
+
+        [Serializable]
+        private class CreateCharacterRequest
+        {
+            public string name;
+            public int faction_id;
+            public int class_id;
+        }
+
+        [Serializable]
+        private class AssignAbilityRequest
+        {
+            public int ability_id;
+        }
+
+        [Serializable]
+        private class TrainSkillRequest
+        {
+            public int skill_id;
+            public int experience_gained;
+        }
+
+        [Serializable]
+        private class ZoneEnterRequest
+        {
+            public int character_id;
+            public int zone_id;
+            public PositionRequest position;
+        }
+
+        [Serializable]
+        private class PositionRequest
+        {
+            public float x;
+            public float y;
+        }
+
+        [Serializable]
+        private class CombatRequest
+        {
+            public int character_id;
+            public int npc_id;
+            public string ability_code;
+        }
+    }
+}

--- a/client/unity/Assets/Scripts/Playtest/Models.cs
+++ b/client/unity/Assets/Scripts/Playtest/Models.cs
@@ -1,0 +1,142 @@
+using System;
+using UnityEngine;
+
+namespace Triarch.Playtest
+{
+    [Serializable]
+    public class AuthResponse
+    {
+        public string token;
+        public string expires_at;
+        public PlayerProfile player;
+    }
+
+    [Serializable]
+    public class PlayerProfile
+    {
+        public int id;
+        public string email;
+        public string display_name;
+    }
+
+    [Serializable]
+    public class ErrorResponse
+    {
+        public ErrorDetail error;
+    }
+
+    [Serializable]
+    public class ErrorDetail
+    {
+        public string code;
+        public string message;
+    }
+
+    [Serializable]
+    public class CharacterSummary
+    {
+        public int id;
+        public string name;
+        public int faction_id;
+        public int class_id;
+        public int level;
+    }
+
+    [Serializable]
+    public class CharacterList
+    {
+        public CharacterSummary[] characters;
+    }
+
+    [Serializable]
+    public class ZoneInfo
+    {
+        public int id;
+        public string name;
+        public string risk_level;
+    }
+
+    [Serializable]
+    public class FactionInfo
+    {
+        public int id;
+        public string name;
+        public string code;
+    }
+
+    [Serializable]
+    public class ClassInfo
+    {
+        public int id;
+        public string name;
+        public string code;
+        public AbilityInfo[] abilities;
+    }
+
+    [Serializable]
+    public class AbilityInfo
+    {
+        public int id;
+        public string name;
+        public string code;
+        public string ability_type;
+        public int cooldown_seconds;
+    }
+
+    [Serializable]
+    public class ReferenceList<T>
+    {
+        public T[] items;
+    }
+
+    [Serializable]
+    public class WorldStateResponse
+    {
+        public int character_id;
+        public ZoneInfo zone;
+        public WorldPosition position;
+    }
+
+    [Serializable]
+    public class WorldPosition
+    {
+        public float x;
+        public float y;
+    }
+
+    [Serializable]
+    public class NpcInfo
+    {
+        public int id;
+        public string code;
+        public string name;
+        public float current_hp;
+        public float max_hp;
+        public bool is_alive;
+    }
+
+    [Serializable]
+    public class NpcListResponse
+    {
+        public int zone_id;
+        public NpcInfo[] npcs;
+    }
+
+    [Serializable]
+    public class CombatResponse
+    {
+        public CharacterCombatState character;
+        public NpcInfo npc;
+        public int damage;
+        public int retaliated_damage;
+    }
+
+    [Serializable]
+    public class CharacterCombatState
+    {
+        public int id;
+        public int current_hp;
+        public int max_hp;
+        public bool is_dead;
+    }
+}

--- a/client/unity/Assets/Scripts/Playtest/PlaytestBootstrap.cs
+++ b/client/unity/Assets/Scripts/Playtest/PlaytestBootstrap.cs
@@ -1,0 +1,522 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Triarch.Playtest
+{
+    public class PlaytestBootstrap : MonoBehaviour
+    {
+        [SerializeField] private ApiClient apiClient;
+        [SerializeField] private GameObject playerAvatar;
+        [SerializeField] private GameObject targetNpc;
+
+        private readonly List<CharacterSummary> characters = new();
+        private readonly List<FactionInfo> factions = new();
+        private readonly List<ClassInfo> classes = new();
+        private readonly List<ZoneInfo> zones = new();
+        private readonly List<AbilityInfo> abilities = new();
+        private readonly List<NpcInfo> npcs = new();
+
+        private int currentCharacterId;
+        private int currentZoneId;
+
+        private Text output;
+        private Dropdown factionDropdown;
+        private Dropdown classDropdown;
+        private Dropdown characterDropdown;
+        private Dropdown zoneDropdown;
+        private Dropdown abilityDropdown;
+        private Dropdown npcDropdown;
+        private InputField emailField;
+        private InputField passwordField;
+        private InputField displayNameField;
+        private InputField characterNameField;
+
+        private void Awake()
+        {
+            if (apiClient == null)
+            {
+                apiClient = gameObject.AddComponent<ApiClient>();
+            }
+        }
+
+        private void Start()
+        {
+            BuildUi();
+            SpawnActors();
+        }
+
+        private void BuildUi()
+        {
+            var canvas = new GameObject("PlaytestCanvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            var canvasComp = canvas.GetComponent<Canvas>();
+            canvasComp.renderMode = RenderMode.ScreenSpaceOverlay;
+            var scaler = canvas.GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1280, 720);
+
+            var panel = new GameObject("Panel", typeof(Image));
+            panel.transform.SetParent(canvas.transform, false);
+            var panelImage = panel.GetComponent<Image>();
+            panelImage.color = new Color(0.08f, 0.08f, 0.12f, 0.85f);
+            var panelRect = panel.GetComponent<RectTransform>();
+            panelRect.anchorMin = new Vector2(0.02f, 0.02f);
+            panelRect.anchorMax = new Vector2(0.4f, 0.98f);
+            panelRect.offsetMin = Vector2.zero;
+            panelRect.offsetMax = Vector2.zero;
+
+            var layout = panel.AddComponent<VerticalLayoutGroup>();
+            layout.padding = new RectOffset(12, 12, 12, 12);
+            layout.spacing = 8;
+
+            var header = CreateText("Triarch Playtest", panel.transform, 18, FontStyle.Bold);
+            header.alignment = TextAnchor.MiddleLeft;
+
+            emailField = CreateInput("Email", panel.transform);
+            passwordField = CreateInput("Password", panel.transform);
+            passwordField.contentType = InputField.ContentType.Password;
+            displayNameField = CreateInput("Display Name", panel.transform);
+
+            var authRow = CreateHorizontal(panel.transform);
+            CreateButton("Register", authRow, () => StartCoroutine(HandleRegister()));
+            CreateButton("Login", authRow, () => StartCoroutine(HandleLogin()));
+
+            CreateDivider(panel.transform);
+
+            CreateButton("Load Reference Data", panel.transform, () => StartCoroutine(LoadReferenceData()));
+
+            factionDropdown = CreateDropdown("Faction", panel.transform);
+            classDropdown = CreateDropdown("Class", panel.transform);
+            characterNameField = CreateInput("Character Name", panel.transform);
+            CreateButton("Create Character", panel.transform, () => StartCoroutine(CreateCharacter()));
+
+            characterDropdown = CreateDropdown("Characters", panel.transform);
+            characterDropdown.onValueChanged.AddListener(_ => SelectCharacter());
+
+            zoneDropdown = CreateDropdown("Zone", panel.transform);
+            CreateButton("Enter Zone", panel.transform, () => StartCoroutine(EnterZone()));
+            CreateButton("World State", panel.transform, () => StartCoroutine(GetWorldState()));
+
+            abilityDropdown = CreateDropdown("Ability", panel.transform);
+            npcDropdown = CreateDropdown("Target NPC", panel.transform);
+            CreateButton("Attack", panel.transform, () => StartCoroutine(AttackNpc()));
+
+            output = CreateText("Output", panel.transform, 12, FontStyle.Normal);
+            output.alignment = TextAnchor.UpperLeft;
+            output.horizontalOverflow = HorizontalWrapMode.Wrap;
+            output.verticalOverflow = VerticalWrapMode.Overflow;
+            output.text = "Ready.";
+        }
+
+        private void SpawnActors()
+        {
+            playerAvatar = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            playerAvatar.name = "PlayerAvatar";
+            playerAvatar.transform.position = new Vector3(0, 0.5f, 0);
+            playerAvatar.AddComponent<SimpleAnimator>().Configure(Color.cyan);
+
+            targetNpc = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            targetNpc.name = "NpcTarget";
+            targetNpc.transform.position = new Vector3(3f, 0.5f, 0);
+            targetNpc.AddComponent<SimpleAnimator>().Configure(Color.red);
+        }
+
+        private IEnumerator HandleRegister()
+        {
+            yield return apiClient.Register(emailField.text, passwordField.text, displayNameField.text, raw =>
+            {
+                output.text = raw;
+            });
+        }
+
+        private IEnumerator HandleLogin()
+        {
+            yield return apiClient.Login(emailField.text, passwordField.text, (data, raw) =>
+            {
+                output.text = raw;
+            });
+        }
+
+        private IEnumerator LoadReferenceData()
+        {
+            yield return apiClient.GetFactions(raw =>
+            {
+                factions.Clear();
+                try
+                {
+                    var data = JsonArrayUtility.FromJson<FactionInfo>(raw);
+                    factions.AddRange(data);
+                    UpdateDropdown(factionDropdown, factions.Select(f => f.name).ToList());
+                }
+                catch (Exception ex)
+                {
+                    output.text = ex.Message;
+                }
+            });
+
+            yield return apiClient.GetClasses(raw =>
+            {
+                classes.Clear();
+                try
+                {
+                    var data = JsonArrayUtility.FromJson<ClassInfo>(raw);
+                    classes.AddRange(data);
+                    UpdateDropdown(classDropdown, classes.Select(c => c.name).ToList());
+                    if (classes.Count > 0)
+                    {
+                        abilities.Clear();
+                        abilities.AddRange(classes[0].abilities ?? Array.Empty<AbilityInfo>());
+                        UpdateDropdown(abilityDropdown, abilities.Select(a => a.code).ToList());
+                    }
+                }
+                catch (Exception ex)
+                {
+                    output.text = ex.Message;
+                }
+            });
+
+            yield return apiClient.GetZones(raw =>
+            {
+                zones.Clear();
+                try
+                {
+                    var data = JsonArrayUtility.FromJson<ZoneInfo>(raw);
+                    zones.AddRange(data);
+                    UpdateDropdown(zoneDropdown, zones.Select(z => z.name).ToList());
+                }
+                catch (Exception ex)
+                {
+                    output.text = ex.Message;
+                }
+            });
+
+            output.text = "Reference data loaded.";
+        }
+
+        private IEnumerator CreateCharacter()
+        {
+            if (factions.Count == 0 || classes.Count == 0)
+            {
+                output.text = "Load reference data first.";
+                yield break;
+            }
+
+            var faction = factions[Mathf.Clamp(factionDropdown.value, 0, factions.Count - 1)];
+            var chosenClass = classes[Mathf.Clamp(classDropdown.value, 0, classes.Count - 1)];
+
+            yield return apiClient.CreateCharacter(characterNameField.text, faction.id, chosenClass.id, raw =>
+            {
+                output.text = raw;
+            });
+
+            yield return StartCoroutine(RefreshCharacters());
+        }
+
+        private IEnumerator RefreshCharacters()
+        {
+            yield return apiClient.GetCharacters(raw =>
+            {
+                characters.Clear();
+                try
+                {
+                    var data = JsonArrayUtility.FromJson<CharacterSummary>(raw);
+                    characters.AddRange(data);
+                    UpdateDropdown(characterDropdown, characters.Select(c => c.name).ToList());
+                    SelectCharacter();
+                }
+                catch (Exception ex)
+                {
+                    output.text = ex.Message;
+                }
+            });
+        }
+
+        private void SelectCharacter()
+        {
+            if (characters.Count == 0) return;
+            currentCharacterId = characters[Mathf.Clamp(characterDropdown.value, 0, characters.Count - 1)].id;
+        }
+
+        private IEnumerator EnterZone()
+        {
+            if (zones.Count == 0)
+            {
+                output.text = "Load reference data first.";
+                yield break;
+            }
+
+            var zone = zones[Mathf.Clamp(zoneDropdown.value, 0, zones.Count - 1)];
+            currentZoneId = zone.id;
+
+            yield return apiClient.EnterZone(currentCharacterId, zone.id, new Vector2(100, 100), raw =>
+            {
+                output.text = raw;
+            });
+        }
+
+        private IEnumerator GetWorldState()
+        {
+            yield return apiClient.GetWorldState(currentCharacterId, raw =>
+            {
+                output.text = raw;
+            });
+        }
+
+        private IEnumerator AttackNpc()
+        {
+            if (currentZoneId == 0)
+            {
+                output.text = "Enter a zone first.";
+                yield break;
+            }
+
+            if (npcs.Count == 0)
+            {
+                yield return apiClient.GetNpcList(currentZoneId, raw =>
+                {
+                    try
+                    {
+                        var data = JsonUtility.FromJson<NpcListResponse>(raw);
+                        npcs.Clear();
+                        if (data != null && data.npcs != null)
+                        {
+                            npcs.AddRange(data.npcs);
+                            UpdateDropdown(npcDropdown, npcs.Select(n => n.name).ToList());
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        output.text = ex.Message;
+                    }
+                });
+            }
+
+            if (npcs.Count == 0)
+            {
+                output.text = "No NPCs found.";
+                yield break;
+            }
+
+            var npc = npcs[Mathf.Clamp(npcDropdown.value, 0, npcs.Count - 1)];
+            var abilityCode = abilities.Count > 0 && abilityDropdown.value < abilities.Count
+                ? abilities[abilityDropdown.value].code
+                : string.Empty;
+
+            yield return apiClient.AttackNpc(currentCharacterId, npc.id, abilityCode, raw =>
+            {
+                output.text = raw;
+                var animator = playerAvatar.GetComponent<SimpleAnimator>();
+                animator.PlayAttack();
+            });
+        }
+
+        private static void UpdateDropdown(Dropdown dropdown, List<string> options)
+        {
+            dropdown.ClearOptions();
+            dropdown.AddOptions(options);
+        }
+
+        private static HorizontalLayoutGroup CreateHorizontal(Transform parent)
+        {
+            var row = new GameObject("Row", typeof(RectTransform));
+            row.transform.SetParent(parent, false);
+            var layout = row.AddComponent<HorizontalLayoutGroup>();
+            layout.spacing = 8;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = false;
+            return layout;
+        }
+
+        private static void CreateDivider(Transform parent)
+        {
+            var divider = new GameObject("Divider", typeof(Image));
+            divider.transform.SetParent(parent, false);
+            var image = divider.GetComponent<Image>();
+            image.color = new Color(1f, 1f, 1f, 0.1f);
+            var rect = divider.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(0, 2);
+        }
+
+        private static Text CreateText(string content, Transform parent, int size, FontStyle style)
+        {
+            var obj = new GameObject("Text", typeof(Text));
+            obj.transform.SetParent(parent, false);
+            var text = obj.GetComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            text.fontSize = size;
+            text.fontStyle = style;
+            text.color = Color.white;
+            text.text = content;
+            return text;
+        }
+
+        private static InputField CreateInput(string placeholder, Transform parent)
+        {
+            var container = new GameObject($"{placeholder}_Container", typeof(RectTransform));
+            container.transform.SetParent(parent, false);
+
+            var background = new GameObject("Background", typeof(Image));
+            background.transform.SetParent(container.transform, false);
+            var bgImage = background.GetComponent<Image>();
+            bgImage.color = new Color(0.2f, 0.2f, 0.25f, 0.9f);
+            var bgRect = background.GetComponent<RectTransform>();
+            bgRect.anchorMin = Vector2.zero;
+            bgRect.anchorMax = Vector2.one;
+            bgRect.offsetMin = Vector2.zero;
+            bgRect.offsetMax = Vector2.zero;
+
+            var inputObj = new GameObject("InputField", typeof(InputField));
+            inputObj.transform.SetParent(container.transform, false);
+            var input = inputObj.GetComponent<InputField>();
+            input.textComponent = CreateText("", inputObj.transform, 12, FontStyle.Normal);
+            input.placeholder = CreateText(placeholder, inputObj.transform, 12, FontStyle.Italic);
+            input.textComponent.color = Color.white;
+            input.placeholder.color = new Color(1f, 1f, 1f, 0.5f);
+            input.textComponent.alignment = TextAnchor.MiddleLeft;
+            input.placeholder.alignment = TextAnchor.MiddleLeft;
+            inputObj.GetComponent<RectTransform>().sizeDelta = new Vector2(0, 28);
+            return input;
+        }
+
+        private static Dropdown CreateDropdown(string label, Transform parent)
+        {
+            var container = new GameObject($"{label}_Container", typeof(RectTransform));
+            container.transform.SetParent(parent, false);
+            CreateText(label, container.transform, 12, FontStyle.Normal);
+
+            var dropdownObj = new GameObject($"{label}_Dropdown", typeof(Dropdown), typeof(Image));
+            dropdownObj.transform.SetParent(container.transform, false);
+            var dropdown = dropdownObj.GetComponent<Dropdown>();
+            dropdown.captionText = CreateText(label, dropdownObj.transform, 12, FontStyle.Normal);
+            dropdown.captionText.alignment = TextAnchor.MiddleLeft;
+            dropdown.template = CreateDropdownTemplate(dropdownObj.transform);
+            dropdown.options = new List<Dropdown.OptionData> { new Dropdown.OptionData("...") };
+            dropdownObj.GetComponent<RectTransform>().sizeDelta = new Vector2(0, 30);
+            return dropdown;
+        }
+
+        private static RectTransform CreateDropdownTemplate(Transform parent)
+        {
+            var template = new GameObject("Template", typeof(RectTransform), typeof(Image));
+            template.transform.SetParent(parent, false);
+            template.SetActive(false);
+
+            var viewport = new GameObject("Viewport", typeof(RectTransform), typeof(Mask), typeof(Image));
+            viewport.transform.SetParent(template.transform, false);
+            var viewportImage = viewport.GetComponent<Image>();
+            viewportImage.color = new Color(0f, 0f, 0f, 0.8f);
+
+            var content = new GameObject("Content", typeof(RectTransform));
+            content.transform.SetParent(viewport.transform, false);
+            var layout = content.AddComponent<VerticalLayoutGroup>();
+            layout.childControlHeight = true;
+            layout.childForceExpandHeight = false;
+
+            var item = new GameObject("Item", typeof(Toggle), typeof(RectTransform));
+            item.transform.SetParent(content.transform, false);
+            var itemText = CreateText("Option", item.transform, 12, FontStyle.Normal);
+            itemText.alignment = TextAnchor.MiddleLeft;
+
+            var toggle = item.GetComponent<Toggle>();
+            toggle.targetGraphic = item.AddComponent<Image>();
+            toggle.graphic = itemText;
+
+            var templateRect = template.GetComponent<RectTransform>();
+            templateRect.anchorMin = new Vector2(0, 0);
+            templateRect.anchorMax = new Vector2(1, 0);
+            templateRect.pivot = new Vector2(0.5f, 1f);
+            templateRect.sizeDelta = new Vector2(0, 150);
+
+            var viewportRect = viewport.GetComponent<RectTransform>();
+            viewportRect.anchorMin = Vector2.zero;
+            viewportRect.anchorMax = Vector2.one;
+            viewportRect.offsetMin = Vector2.zero;
+            viewportRect.offsetMax = Vector2.zero;
+
+            var contentRect = content.GetComponent<RectTransform>();
+            contentRect.anchorMin = new Vector2(0, 1);
+            contentRect.anchorMax = new Vector2(1, 1);
+            contentRect.pivot = new Vector2(0.5f, 1f);
+
+            var itemRect = item.GetComponent<RectTransform>();
+            itemRect.sizeDelta = new Vector2(0, 24);
+
+            return templateRect;
+        }
+
+        private static Button CreateButton(string label, Transform parent, Action onClick)
+        {
+            var buttonObj = new GameObject(label, typeof(Button), typeof(Image));
+            buttonObj.transform.SetParent(parent, false);
+            var image = buttonObj.GetComponent<Image>();
+            image.color = new Color(0.35f, 0.35f, 0.8f, 1f);
+            var text = CreateText(label, buttonObj.transform, 12, FontStyle.Bold);
+            text.alignment = TextAnchor.MiddleCenter;
+            var rect = buttonObj.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(0, 28);
+            var button = buttonObj.GetComponent<Button>();
+            button.onClick.AddListener(() => onClick?.Invoke());
+            return button;
+        }
+    }
+
+    public class SimpleAnimator : MonoBehaviour
+    {
+        private float time;
+        private Renderer cachedRenderer;
+        private Color baseColor;
+        private bool attackPulse;
+
+        public void Configure(Color color)
+        {
+            cachedRenderer = GetComponent<Renderer>();
+            baseColor = color;
+            if (cachedRenderer != null)
+            {
+                cachedRenderer.material.color = color;
+            }
+        }
+
+        public void PlayAttack()
+        {
+            attackPulse = true;
+            time = 0f;
+        }
+
+        private void Update()
+        {
+            time += Time.deltaTime;
+            var bob = Mathf.Sin(time * 2f) * 0.1f;
+            transform.position = new Vector3(transform.position.x, 0.5f + bob, transform.position.z);
+
+            if (attackPulse && cachedRenderer != null)
+            {
+                var pulse = Mathf.PingPong(time * 6f, 1f);
+                cachedRenderer.material.color = Color.Lerp(baseColor, Color.yellow, pulse);
+                if (time > 0.5f)
+                {
+                    cachedRenderer.material.color = baseColor;
+                    attackPulse = false;
+                }
+            }
+        }
+    }
+
+    public static class JsonArrayUtility
+    {
+        public static T[] FromJson<T>(string json)
+        {
+            var wrapper = JsonUtility.FromJson<ArrayWrapper<T>>($"{{\"items\":{json}}}");
+            return wrapper.items ?? Array.Empty<T>();
+        }
+
+        [Serializable]
+        private class ArrayWrapper<T>
+        {
+            public T[] items;
+        }
+    }
+}

--- a/client/unity/Packages/manifest.json
+++ b/client/unity/Packages/manifest.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "com.unity.ugui": "1.0.0",
+    "com.unity.modules.audio": "1.0.0",
+    "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.ui": "1.0.0",
+    "com.unity.modules.uielements": "1.0.0"
+  }
+}

--- a/client/unity/ProjectSettings/ProjectVersion.txt
+++ b/client/unity/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,2 @@
+m_EditorVersion: 2022.3.21f1
+m_EditorVersionWithRevision: 2022.3.21f1 (bf09ca542b87)

--- a/client/unity/README.md
+++ b/client/unity/README.md
@@ -1,0 +1,22 @@
+# Unity Playtest Client
+
+This Unity client provides a lightweight, animated playtest surface for the Triarch server.
+
+## Requirements
+- Unity 2022.3 LTS
+- Triarch server running locally (default `http://localhost:3000`)
+
+## Setup
+1. Open Unity Hub and add the `client/unity` folder as a project.
+2. Open the project and create a new empty scene.
+3. Create an empty GameObject named `PlaytestBootstrap`.
+4. Add the `PlaytestBootstrap` component (Assets/Scripts/Playtest/PlaytestBootstrap.cs).
+5. Press Play. The UI is generated at runtime.
+
+## Features
+- Login/register against the server.
+- Load reference data for factions/classes/zones.
+- Create characters and enter a zone.
+- Fetch NPCs and attack with a simple animation pulse.
+
+> The client is renderer-only; all authoritative logic stays on the server.

--- a/design/assumptions.md
+++ b/design/assumptions.md
@@ -2,3 +2,6 @@
 
 - Inventory uses a single stack per item per character for the initial vertical slice. Stack limits apply to the total quantity stored for that item in `character_inventory`. Multi-stack inventories will be added later as a dedicated system.
 - World positions are only updated through the `zone-enter` RPC until movement syncing lands, so gathering range checks use the stored position from `character_positions` with static node coordinates in `/data/nodes.json`.
+- Zone-tier death loot uses deterministic rules to keep tests predictable: SAFE drops nothing, CONTESTED drops half of each inventory stack (rounded down), and HIGH_RISK drops full stacks.
+- Combat uses a simple base damage formula (`10 + power * 2`) and a fixed attack range (12 units) for the training dummy slice until full combat tuning lands.
+- Betrayal reputation resets set all factions to a neutral baseline (200), apply a penalty to the previous faction (-500), and grant a bonus to the new faction (400) to make the switch feel impactful during tests.

--- a/design/betrayal.md
+++ b/design/betrayal.md
@@ -1,0 +1,24 @@
+# Betrayal Questline
+
+## Goals
+- Allow faction switching only through a server-authoritative questline.
+- Enforce reputation resets and penalties.
+
+## Steps
+1. `RENOUNCE` - Player commits to betrayal.
+2. `PROVE` - Player advances once to show intent.
+3. `COMPLETE` - Server swaps faction and applies reputation changes.
+
+## Endpoints
+- `POST /api/betrayal/start` — Begins the questline.
+- `POST /api/betrayal/advance` — Advances the current step.
+- `GET /api/betrayal/status/:characterId` — Reads latest quest state.
+
+## Reputation Effects
+- All factions reset to baseline (200).
+- Previous faction receives a penalty (-500).
+- New faction receives a bonus (+200 on top of baseline).
+
+## Guardrails
+- Only one active betrayal quest per character.
+- Target faction must differ from current faction.

--- a/design/client_playtest.md
+++ b/design/client_playtest.md
@@ -1,0 +1,16 @@
+# Unity Playtest Client
+
+## Goals
+- Provide a lightweight Unity client that renders the vertical slice and drives server-authoritative actions.
+- Keep UI minimal and mobile-friendly while still allowing quick smoke tests.
+
+## Runtime Flow
+1. Player logs in or registers.
+2. Client loads reference data (factions/classes/zones) for dropdown selection.
+3. Player creates/selects a character.
+4. Player enters a zone and can fetch NPCs.
+5. Player attacks with a simple animation pulse to visualize combat.
+
+## Guardrails
+- The client never applies authoritative outcomes.
+- All mutations go through server APIs and display raw responses.

--- a/design/combat.md
+++ b/design/combat.md
@@ -1,0 +1,31 @@
+# Combat Vertical Slice
+
+## Goals
+- Deliver a server-authoritative PvE encounter loop with cooldown validation.
+- Provide deterministic, testable combat math for the training dummy NPC.
+
+## Core Flow
+1. Client requests NPC list for a zone (`GET /api/combat/npcs/:zoneId`).
+2. Client issues `POST /api/combat/attack` with character + NPC IDs.
+3. Server validates:
+   - Session token and player ownership.
+   - Character is alive.
+   - Character and NPC are in the same zone.
+   - Target is in range (12 units).
+   - Ability cooldown (if supplied).
+4. Server applies damage, updates NPC HP, and resolves NPC retaliation.
+5. If the character dies, the death/loot rules apply immediately.
+
+## Cooldowns
+- Cooldowns are stored in `character_ability_cooldowns` keyed by character + ability.
+- Server checks last_used_at against ability cooldown_seconds.
+
+## NPCs
+- NPC templates live in `npc_templates`.
+- Spawn instances live in `npc_spawns` and hold current HP and respawn timers.
+- Training dummy is seeded into zone 1 for immediate playtesting.
+
+## Tunables
+- Base damage: `10 + power * 2`.
+- Attack range: 12 units.
+- Respawn time: 60 seconds for the training dummy.

--- a/design/death_loot.md
+++ b/design/death_loot.md
@@ -1,0 +1,26 @@
+# Death & Loot Rules
+
+## Goals
+- Enforce risk-tier loot drops server-side.
+- Create loot containers that players can claim.
+
+## Zone Rules
+- SAFE: No loot drops on death.
+- CONTESTED: Drop half of each stack (rounded down).
+- HIGH_RISK: Drop full inventory.
+
+## Flow
+1. Character HP reaches 0 in combat.
+2. Server:
+   - Marks character dead in `character_state`.
+   - Calculates drop stacks based on zone rule.
+   - Creates `loot_containers` and `loot_container_items`.
+   - Removes dropped items from `character_inventory`.
+
+## Loot Claim
+- `GET /api/loot/containers/:characterId` lists containers in the character's zone.
+- `POST /api/loot/containers/:containerId/claim` moves items to inventory after range + stack checks.
+
+## Anti-Cheat Checks
+- Zone alignment and distance checks for loot claims.
+- Stack limit validation before transfer.

--- a/docs/API.md
+++ b/docs/API.md
@@ -283,6 +283,11 @@ Server-authoritative world state for character positions.
 
 Enter a zone and set the character's authoritative position.
 
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
 **Request Body:**
 ```json
 {
@@ -325,6 +330,11 @@ Enter a zone and set the character's authoritative position.
 
 Fetch the current authoritative world state for a character.
 
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
 **Response:**
 ```json
 {
@@ -361,6 +371,11 @@ Server-authoritative character inventory.
 
 Fetch a character's inventory.
 
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
 **Response:**
 ```json
 {
@@ -389,6 +404,11 @@ Fetch a character's inventory.
 ### POST /api/inventory/:characterId/add
 
 Add an item stack to a character's inventory.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
 
 **Request Body:**
 ```json
@@ -422,6 +442,11 @@ Add an item stack to a character's inventory.
 ### POST /api/inventory/:characterId/remove
 
 Remove quantity from a character's inventory.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
 
 **Request Body:**
 ```json
@@ -461,6 +486,11 @@ Server-authoritative gathering and resource nodes.
 ### GET /api/gathering/nodes/:zoneId
 
 List available gathering nodes for a zone.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
 
 **Response:**
 ```json
@@ -503,6 +533,11 @@ List available gathering nodes for a zone.
 ### POST /api/gathering/attempt
 
 Attempt to gather from a node (validated server-side).
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
 
 **Request Body:**
 ```json
@@ -604,6 +639,11 @@ Player characters with stats, abilities, and skills.
 
 List all characters.
 
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
 **Response:**
 ```json
 [
@@ -630,6 +670,11 @@ List all characters.
 ### GET /api/characters/:id
 
 Get full details of a character including abilities, traits, and skills.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
 
 **Response:**
 ```json
@@ -684,6 +729,11 @@ Get full details of a character including abilities, traits, and skills.
 
 Create a new character.
 
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
 **Request Body:**
 ```json
 {
@@ -717,6 +767,11 @@ Create a new character.
 ### PATCH /api/characters/:id/stats
 
 Update character stats (Power, Control, Resilience).
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
 
 **Request Body:**
 ```json
@@ -753,6 +808,11 @@ Update character stats (Power, Control, Resilience).
 
 Assign an ability to a character.
 
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
 **Request Body:**
 ```json
 {
@@ -779,6 +839,11 @@ Assign an ability to a character.
 ### POST /api/characters/:id/traits
 
 Assign a passive trait to a character.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
 
 **Request Body:**
 ```json
@@ -808,6 +873,11 @@ Assign a passive trait to a character.
 
 Update or add a character's skill experience.
 
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
 **Request Body:**
 ```json
 {
@@ -832,6 +902,222 @@ Update or add a character's skill experience.
 **Error Responses:**
 - 400 Bad Request: Missing required fields or invalid skill
 - 404 Not Found: Character not found
+
+---
+
+## Combat
+
+Basic PvE combat against server-controlled NPCs.
+
+### GET /api/combat/npcs/:zoneId
+
+List NPC spawns in a zone.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Response:**
+```json
+{
+  "zone_id": 1,
+  "npcs": [
+    {
+      "id": 1,
+      "code": "TRAINING_DUMMY",
+      "name": "Training Dummy",
+      "zone_id": 1,
+      "position": { "x": 108, "y": 96 },
+      "current_hp": 120,
+      "max_hp": 120,
+      "base_damage": 6,
+      "respawn_seconds": 60,
+      "is_alive": true
+    }
+  ],
+  "server_time": "2024-01-01T00:00:00.000Z"
+}
+```
+
+### POST /api/combat/attack
+
+Attack an NPC with optional ability.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Request Body:**
+```json
+{
+  "character_id": 1,
+  "npc_id": 1,
+  "ability_code": "SHIELD_SLAM"
+}
+```
+
+**Response:**
+```json
+{
+  "character": {
+    "id": 1,
+    "current_hp": 112,
+    "max_hp": 120,
+    "is_dead": false
+  },
+  "npc": {
+    "id": 1,
+    "code": "TRAINING_DUMMY",
+    "name": "Training Dummy",
+    "current_hp": 90,
+    "max_hp": 120,
+    "is_alive": true
+  },
+  "damage": 30,
+  "retaliated_damage": 6,
+  "death": null,
+  "server_time": "2024-01-01T00:00:00.000Z"
+}
+```
+
+### POST /api/combat/revive
+
+Revive a dead character to full HP.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Request Body:**
+```json
+{ "character_id": 1 }
+```
+
+---
+
+## Loot
+
+Loot containers created from death drops.
+
+### GET /api/loot/containers/:characterId
+
+List loot containers in the character's current zone.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Response:**
+```json
+{
+  "character_id": 1,
+  "zone_id": 2,
+  "containers": [
+    {
+      "id": 1,
+      "zone_id": 2,
+      "position": { "x": 120, "y": 88 },
+      "owner_character_id": 1,
+      "items": [
+        {
+          "item_code": "IRON_ORE",
+          "quantity": 3,
+          "item": { "code": "IRON_ORE", "name": "Iron Ore" }
+        }
+      ],
+      "created_at": "2024-01-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+### POST /api/loot/containers/:containerId/claim
+
+Claim a loot container and move items into inventory.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Request Body:**
+```json
+{ "character_id": 1 }
+```
+
+---
+
+## Reputation
+
+Faction reputation per character.
+
+### GET /api/reputation/:characterId
+
+Fetch current reputation values.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Response:**
+```json
+{
+  "character_id": 1,
+  "reputation": [
+    {
+      "faction": { "id": 1, "name": "Iron Covenant", "code": "IRON_COVENANT" },
+      "value": 500
+    }
+  ]
+}
+```
+
+---
+
+## Betrayal
+
+Faction switching questline (server-authoritative).
+
+### GET /api/betrayal/status/:characterId
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+### POST /api/betrayal/start
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Request Body:**
+```json
+{
+  "character_id": 1,
+  "target_faction_id": 2
+}
+```
+
+### POST /api/betrayal/advance
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Request Body:**
+```json
+{
+  "character_id": 1
+}
+```
 
 ---
 

--- a/migrations/013_character_player.sql
+++ b/migrations/013_character_player.sql
@@ -1,0 +1,16 @@
+-- Link characters to players
+ALTER TABLE characters
+  ADD COLUMN IF NOT EXISTS player_id INTEGER REFERENCES players(id);
+
+INSERT INTO players (email, display_name, password_hash, password_salt)
+SELECT 'system@triarch.local', 'System', 'migration', 'migration'
+WHERE NOT EXISTS (SELECT 1 FROM players WHERE email = 'system@triarch.local');
+
+UPDATE characters
+SET player_id = (SELECT id FROM players WHERE email = 'system@triarch.local')
+WHERE player_id IS NULL;
+
+ALTER TABLE characters
+  ALTER COLUMN player_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_characters_player ON characters(player_id);

--- a/migrations/014_character_state.sql
+++ b/migrations/014_character_state.sql
@@ -1,0 +1,13 @@
+-- Character state for combat and death handling
+CREATE TABLE IF NOT EXISTS character_state (
+  character_id INTEGER PRIMARY KEY REFERENCES characters(id) ON DELETE CASCADE,
+  current_hp INTEGER NOT NULL CHECK (current_hp >= 0),
+  max_hp INTEGER NOT NULL CHECK (max_hp > 0),
+  is_dead BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO character_state (character_id, current_hp, max_hp, is_dead)
+SELECT id, 120, 120, FALSE
+FROM characters
+ON CONFLICT (character_id) DO NOTHING;

--- a/migrations/015_combat_npcs.sql
+++ b/migrations/015_combat_npcs.sql
@@ -1,0 +1,43 @@
+-- NPC templates and spawns for combat encounters
+CREATE TABLE IF NOT EXISTS npc_templates (
+  id SERIAL PRIMARY KEY,
+  code VARCHAR(50) NOT NULL UNIQUE,
+  name VARCHAR(100) NOT NULL,
+  base_hp INTEGER NOT NULL CHECK (base_hp > 0),
+  base_damage INTEGER NOT NULL CHECK (base_damage >= 0),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS npc_spawns (
+  id SERIAL PRIMARY KEY,
+  template_id INTEGER NOT NULL REFERENCES npc_templates(id) ON DELETE CASCADE,
+  zone_id INTEGER NOT NULL REFERENCES zones(id),
+  position_x NUMERIC(10, 3) NOT NULL,
+  position_y NUMERIC(10, 3) NOT NULL,
+  current_hp INTEGER NOT NULL CHECK (current_hp >= 0),
+  respawn_seconds INTEGER NOT NULL CHECK (respawn_seconds > 0),
+  last_defeated_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (template_id, zone_id, position_x, position_y)
+);
+
+CREATE INDEX IF NOT EXISTS idx_npc_spawns_zone ON npc_spawns(zone_id);
+
+CREATE TABLE IF NOT EXISTS character_ability_cooldowns (
+  character_id INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  ability_id INTEGER NOT NULL REFERENCES abilities(id) ON DELETE CASCADE,
+  last_used_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (character_id, ability_id)
+);
+
+INSERT INTO npc_templates (code, name, base_hp, base_damage)
+VALUES ('TRAINING_DUMMY', 'Training Dummy', 120, 6)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO npc_spawns (template_id, zone_id, position_x, position_y, current_hp, respawn_seconds)
+SELECT id, 1, 108.0, 96.0, 120, 60
+FROM npc_templates
+WHERE code = 'TRAINING_DUMMY'
+ON CONFLICT (template_id, zone_id, position_x, position_y) DO NOTHING;

--- a/migrations/016_loot_containers.sql
+++ b/migrations/016_loot_containers.sql
@@ -1,0 +1,20 @@
+-- Loot containers created on death or drops
+CREATE TABLE IF NOT EXISTS loot_containers (
+  id SERIAL PRIMARY KEY,
+  zone_id INTEGER NOT NULL REFERENCES zones(id),
+  position_x NUMERIC(10, 3) NOT NULL,
+  position_y NUMERIC(10, 3) NOT NULL,
+  owner_character_id INTEGER REFERENCES characters(id),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS loot_container_items (
+  id SERIAL PRIMARY KEY,
+  container_id INTEGER NOT NULL REFERENCES loot_containers(id) ON DELETE CASCADE,
+  item_code VARCHAR(64) NOT NULL,
+  quantity INTEGER NOT NULL CHECK (quantity > 0),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_loot_containers_zone ON loot_containers(zone_id);
+CREATE INDEX IF NOT EXISTS idx_loot_items_container ON loot_container_items(container_id);

--- a/migrations/017_reputation_betrayal.sql
+++ b/migrations/017_reputation_betrayal.sql
@@ -1,0 +1,29 @@
+-- Reputation tracking per character/faction
+CREATE TABLE IF NOT EXISTS character_reputation (
+  character_id INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  faction_id INTEGER NOT NULL REFERENCES factions(id) ON DELETE CASCADE,
+  value INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (character_id, faction_id)
+);
+
+INSERT INTO character_reputation (character_id, faction_id, value)
+SELECT c.id, f.id, CASE WHEN c.faction_id = f.id THEN 500 ELSE 0 END
+FROM characters c
+CROSS JOIN factions f
+ON CONFLICT (character_id, faction_id) DO NOTHING;
+
+-- Betrayal questline state
+CREATE TABLE IF NOT EXISTS betrayal_quests (
+  id SERIAL PRIMARY KEY,
+  character_id INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  target_faction_id INTEGER NOT NULL REFERENCES factions(id),
+  current_step VARCHAR(20) NOT NULL,
+  status VARCHAR(20) NOT NULL,
+  started_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  CHECK (current_step IN ('RENOUNCE', 'PROVE', 'COMPLETE')),
+  CHECK (status IN ('IN_PROGRESS', 'COMPLETED', 'FAILED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_betrayal_character ON betrayal_quests(character_id);

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,589 @@
+const STORAGE_KEY = "triarch.session.token";
+
+let sessionToken = localStorage.getItem(STORAGE_KEY) ?? "";
+let selectedCharacterId = null;
+const referenceData = {
+  factions: [],
+  classes: [],
+  skills: [],
+  zones: [],
+};
+const classDetails = new Map();
+
+const tokenPreview = document.getElementById("tokenPreview");
+
+tokenPreview.textContent = sessionToken ? `${sessionToken.slice(0, 12)}...` : "not set";
+
+const setOutput = (id, payload) => {
+  const el = document.getElementById(id);
+  el.textContent = JSON.stringify(payload, null, 2);
+};
+
+const apiFetch = async (url, options = {}) => {
+  const headers = {
+    "Content-Type": "application/json",
+    ...options.headers,
+  };
+
+  if (sessionToken) {
+    headers.Authorization = `Bearer ${sessionToken}`;
+  }
+
+  const response = await fetch(url, { ...options, headers });
+  const data = await response.json().catch(() => ({}));
+  return { ok: response.ok, status: response.status, data };
+};
+
+const ensureToken = () => {
+  if (!sessionToken) {
+    setOutput("authOutput", {
+      error: "Login required",
+      message: "Please log in and make sure a session token is set.",
+    });
+    return false;
+  }
+  return true;
+};
+
+const getSelectedCharacterId = () => {
+  if (selectedCharacterId) {
+    return selectedCharacterId;
+  }
+  return null;
+};
+
+const ensureCharacter = () => {
+  const characterId = getSelectedCharacterId();
+  if (!characterId) {
+    setOutput("charactersOutput", {
+      error: "No character selected",
+      message: "Pick a character from the dropdown or create one first.",
+    });
+    return null;
+  }
+  return characterId;
+};
+
+const populateSelect = (elementId, options, formatter, placeholder = "Select...") => {
+  const select = document.getElementById(elementId);
+  select.innerHTML = "";
+  const placeholderOption = document.createElement("option");
+  placeholderOption.value = "";
+  placeholderOption.textContent = placeholder;
+  select.appendChild(placeholderOption);
+
+  for (const option of options) {
+    const el = document.createElement("option");
+    el.value = String(option.value);
+    el.textContent = option.label;
+    select.appendChild(el);
+  }
+};
+
+const refreshReferenceSelects = () => {
+  populateSelect(
+    "characterFaction",
+    referenceData.factions.map((faction) => ({
+      value: faction.id,
+      label: `${faction.name} (${faction.code})`,
+    })),
+    null,
+    "Select faction"
+  );
+
+  populateSelect(
+    "characterClass",
+    referenceData.classes.map((entry) => ({
+      value: entry.id,
+      label: `${entry.name} (${entry.code})`,
+    })),
+    null,
+    "Select class"
+  );
+
+  populateSelect(
+    "skillSelect",
+    referenceData.skills.map((skill) => ({
+      value: skill.id,
+      label: `${skill.name} (${skill.code})`,
+    })),
+    null,
+    "Select skill"
+  );
+
+  populateSelect(
+    "zoneId",
+    referenceData.zones.map((zone) => ({
+      value: zone.id,
+      label: `${zone.name} (${zone.risk_level})`,
+    })),
+    null,
+    "Select zone"
+  );
+
+  populateSelect(
+    "betrayalTarget",
+    referenceData.factions.map((faction) => ({
+      value: faction.id,
+      label: `${faction.name} (${faction.code})`,
+    })),
+    null,
+    "Select target faction"
+  );
+};
+
+const updateAbilitySelects = (abilities) => {
+  populateSelect(
+    "abilitySelect",
+    abilities.map((ability) => ({
+      value: ability.id,
+      label: `${ability.name} (${ability.code})`,
+    })),
+    null,
+    "Select ability"
+  );
+
+  populateSelect(
+    "abilityCode",
+    [{ value: "", label: "Basic attack" }].concat(
+      abilities.map((ability) => ({
+        value: ability.code,
+        label: `${ability.name} (${ability.code})`,
+      }))
+    ),
+    null,
+    "Basic attack"
+  );
+};
+
+const updateCharacterSelect = (characters) => {
+  const options = characters.map((character) => ({
+    value: character.id,
+    label: `${character.name} (Lv ${character.level})`,
+  }));
+  populateSelect("selectedCharacter", options, null, "Select character");
+
+  if (options.length > 0) {
+    selectedCharacterId = Number(options[0].value);
+    document.getElementById("selectedCharacter").value = String(selectedCharacterId);
+  }
+};
+
+const updateNodeSelect = (nodes) => {
+  populateSelect(
+    "nodeCode",
+    nodes.map((node) => ({
+      value: node.code,
+      label: `${node.name} (${node.code})`,
+    })),
+    null,
+    "Select node"
+  );
+};
+
+const updateNpcSelect = (npcs) => {
+  populateSelect(
+    "npcId",
+    npcs.map((npc) => ({
+      value: npc.id,
+      label: `${npc.name} (${npc.code})`,
+    })),
+    null,
+    "Select NPC"
+  );
+};
+
+const updateLootSelect = (containers) => {
+  populateSelect(
+    "containerId",
+    containers.map((container) => ({
+      value: container.id,
+      label: `Container #${container.id}`,
+    })),
+    null,
+    "Select container"
+  );
+};
+
+const loadReferenceData = async () => {
+  const [factionsRes, classesRes, skillsRes, zonesRes] = await Promise.all([
+    apiFetch("/api/factions"),
+    apiFetch("/api/classes"),
+    apiFetch("/api/skills"),
+    apiFetch("/api/zones"),
+  ]);
+
+  if (factionsRes.ok) referenceData.factions = factionsRes.data;
+  if (classesRes.ok) referenceData.classes = classesRes.data;
+  if (skillsRes.ok) referenceData.skills = skillsRes.data;
+  if (zonesRes.ok) referenceData.zones = zonesRes.data;
+
+  refreshReferenceSelects();
+  setOutput("referenceOutput", {
+    factions: factionsRes.data,
+    classes: classesRes.data,
+    skills: skillsRes.data,
+    zones: zonesRes.data,
+  });
+};
+
+document.getElementById("registerBtn").addEventListener("click", async () => {
+  const payload = {
+    email: document.getElementById("registerEmail").value,
+    password: document.getElementById("registerPassword").value,
+    display_name: document.getElementById("registerDisplay").value,
+  };
+
+  const result = await apiFetch("/api/auth/register", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  setOutput("authOutput", result);
+});
+
+document.getElementById("loginBtn").addEventListener("click", async () => {
+  const payload = {
+    email: document.getElementById("loginEmail").value,
+    password: document.getElementById("loginPassword").value,
+  };
+
+  const result = await apiFetch("/api/auth/login", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  if (result.ok) {
+    sessionToken = result.data.token;
+    localStorage.setItem(STORAGE_KEY, sessionToken);
+    tokenPreview.textContent = `${sessionToken.slice(0, 12)}...`;
+  }
+
+  setOutput("authOutput", result);
+});
+
+document.getElementById("clearTokenBtn").addEventListener("click", () => {
+  sessionToken = "";
+  localStorage.removeItem(STORAGE_KEY);
+  tokenPreview.textContent = "not set";
+});
+
+document.getElementById("loadReferenceBtn").addEventListener("click", loadReferenceData);
+
+document.getElementById("characterClass").addEventListener("change", async (event) => {
+  const classId = event.target.value;
+  if (!classId) {
+    updateAbilitySelects([]);
+    return;
+  }
+
+  if (classDetails.has(classId)) {
+    updateAbilitySelects(classDetails.get(classId).abilities ?? []);
+    return;
+  }
+
+  const result = await apiFetch(`/api/classes/${classId}`);
+  if (result.ok) {
+    classDetails.set(classId, result.data);
+    updateAbilitySelects(result.data.abilities ?? []);
+  } else {
+    setOutput("referenceOutput", result);
+  }
+});
+
+document.getElementById("createCharacterBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+
+  const factionId = Number(document.getElementById("characterFaction").value);
+  const classId = Number(document.getElementById("characterClass").value);
+
+  const payload = {
+    name: document.getElementById("characterName").value,
+    faction_id: factionId,
+    class_id: classId,
+  };
+
+  const result = await apiFetch("/api/characters", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  setOutput("charactersOutput", result);
+});
+
+document.getElementById("listCharactersBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+
+  const result = await apiFetch("/api/characters");
+  if (result.ok && Array.isArray(result.data)) {
+    updateCharacterSelect(result.data);
+  }
+  setOutput("charactersOutput", result);
+});
+
+document.getElementById("selectedCharacter").addEventListener("change", (event) => {
+  selectedCharacterId = event.target.value ? Number(event.target.value) : null;
+});
+
+document.getElementById("trainSkillBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const skillId = Number(document.getElementById("skillSelect").value);
+  const experience = Number(document.getElementById("skillExp").value);
+  const payload = {
+    skill_id: skillId,
+    experience_gained: experience,
+  };
+
+  const result = await apiFetch(`/api/characters/${characterId}/skills`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  setOutput("setupOutput", result);
+});
+
+document.getElementById("assignAbilityBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const abilityId = Number(document.getElementById("abilitySelect").value);
+  const payload = { ability_id: abilityId };
+
+  const result = await apiFetch(`/api/characters/${characterId}/abilities`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  setOutput("setupOutput", result);
+});
+
+document.getElementById("zoneEnterBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const zoneId = Number(document.getElementById("zoneId").value);
+  const payload = {
+    character_id: characterId,
+    zone_id: zoneId,
+    position: {
+      x: Number(document.getElementById("positionX").value),
+      y: Number(document.getElementById("positionY").value),
+    },
+  };
+
+  const result = await apiFetch("/api/world/zone-enter", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  setOutput("worldOutput", result);
+});
+
+document.getElementById("worldStateBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const result = await apiFetch(`/api/world/state/${characterId}`);
+  setOutput("worldOutput", result);
+});
+
+document.getElementById("inventoryBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const result = await apiFetch(`/api/inventory/${characterId}`);
+  setOutput("inventoryOutput", result);
+});
+
+document.getElementById("addItemBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const payload = {
+    item_code: document.getElementById("addItemCode").value,
+    quantity: Number(document.getElementById("addItemQty").value),
+  };
+
+  const result = await apiFetch(`/api/inventory/${characterId}/add`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  setOutput("inventoryOutput", result);
+});
+
+document.getElementById("removeItemBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const payload = {
+    item_code: document.getElementById("removeItemCode").value,
+    quantity: Number(document.getElementById("removeItemQty").value),
+  };
+
+  const result = await apiFetch(`/api/inventory/${characterId}/remove`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  setOutput("inventoryOutput", result);
+});
+
+document.getElementById("listNodesBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const zoneId = Number(document.getElementById("zoneId").value);
+  const result = await apiFetch(`/api/gathering/nodes/${zoneId}`);
+
+  if (result.ok) {
+    updateNodeSelect(result.data.nodes ?? []);
+  }
+
+  setOutput("gatheringOutput", result);
+});
+
+document.getElementById("gatherBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const payload = {
+    character_id: characterId,
+    node_code: document.getElementById("nodeCode").value,
+    client_position: {
+      x: Number(document.getElementById("clientX").value),
+      y: Number(document.getElementById("clientY").value),
+    },
+  };
+
+  const result = await apiFetch("/api/gathering/attempt", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  setOutput("gatheringOutput", result);
+});
+
+document.getElementById("listNpcBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const zoneId = Number(document.getElementById("zoneId").value);
+  const result = await apiFetch(`/api/combat/npcs/${zoneId}`);
+
+  if (result.ok) {
+    updateNpcSelect(result.data.npcs ?? []);
+  }
+
+  setOutput("combatOutput", result);
+});
+
+document.getElementById("attackBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const abilityCode = document.getElementById("abilityCode").value;
+  const payload = {
+    character_id: characterId,
+    npc_id: Number(document.getElementById("npcId").value),
+    ...(abilityCode ? { ability_code: abilityCode } : {}),
+  };
+
+  const result = await apiFetch("/api/combat/attack", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  setOutput("combatOutput", result);
+});
+
+document.getElementById("reviveBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const payload = { character_id: characterId };
+  const result = await apiFetch("/api/combat/revive", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  setOutput("combatOutput", result);
+});
+
+document.getElementById("listLootBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const result = await apiFetch(`/api/loot/containers/${characterId}`);
+  if (result.ok) {
+    updateLootSelect(result.data.containers ?? []);
+  }
+  setOutput("lootOutput", result);
+});
+
+document.getElementById("claimLootBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const containerId = Number(document.getElementById("containerId").value);
+  const payload = { character_id: characterId };
+  const result = await apiFetch(`/api/loot/containers/${containerId}/claim`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  setOutput("lootOutput", result);
+});
+
+document.getElementById("betrayalStartBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const payload = {
+    character_id: characterId,
+    target_faction_id: Number(document.getElementById("betrayalTarget").value),
+  };
+  const result = await apiFetch("/api/betrayal/start", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  setOutput("betrayalOutput", result);
+});
+
+document.getElementById("betrayalAdvanceBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const payload = { character_id: characterId };
+  const result = await apiFetch("/api/betrayal/advance", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  setOutput("betrayalOutput", result);
+});
+
+document.getElementById("betrayalStatusBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const result = await apiFetch(`/api/betrayal/status/${characterId}`);
+  setOutput("betrayalOutput", result);
+});
+
+document.getElementById("reputationBtn").addEventListener("click", async () => {
+  if (!ensureToken()) return;
+  const characterId = ensureCharacter();
+  if (!characterId) return;
+
+  const result = await apiFetch(`/api/reputation/${characterId}`);
+  setOutput("reputationOutput", result);
+});
+
+loadReferenceData();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Triarch: Shattered Realms - Playtest Console</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Triarch: Shattered Realms</h1>
+      <p class="subtitle">Playtest Console (Server-Authoritative Vertical Slice)</p>
+    </header>
+
+    <main>
+      <section class="card">
+        <h2>1. Auth</h2>
+        <div class="grid">
+          <div>
+            <h3>Register</h3>
+            <label>Email <input id="registerEmail" type="email" /></label>
+            <label>Password <input id="registerPassword" type="password" /></label>
+            <label>Display Name <input id="registerDisplay" type="text" /></label>
+            <button id="registerBtn">Register</button>
+          </div>
+          <div>
+            <h3>Login</h3>
+            <label>Email <input id="loginEmail" type="email" /></label>
+            <label>Password <input id="loginPassword" type="password" /></label>
+            <button id="loginBtn">Login</button>
+            <div class="pill">Token: <span id="tokenPreview">not set</span></div>
+            <button class="secondary" id="clearTokenBtn">Clear Token</button>
+          </div>
+        </div>
+        <pre id="authOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>2. Reference Data</h2>
+        <div class="grid">
+          <div>
+            <button id="loadReferenceBtn">Load Factions, Classes, Skills, Zones</button>
+            <p class="helper">Use this before creating characters to populate dropdowns.</p>
+          </div>
+        </div>
+        <pre id="referenceOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>3. Characters</h2>
+        <div class="grid">
+          <div>
+            <h3>Create Character</h3>
+            <label>Name <input id="characterName" type="text" /></label>
+            <label>Faction
+              <select id="characterFaction"></select>
+            </label>
+            <label>Class
+              <select id="characterClass"></select>
+            </label>
+            <button id="createCharacterBtn">Create</button>
+          </div>
+          <div>
+            <h3>Your Characters</h3>
+            <button id="listCharactersBtn">Refresh</button>
+            <label>Selected Character
+              <select id="selectedCharacter"></select>
+            </label>
+          </div>
+        </div>
+        <pre id="charactersOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>4. Character Setup</h2>
+        <div class="grid">
+          <div>
+            <h3>Train Skill</h3>
+            <label>Skill
+              <select id="skillSelect"></select>
+            </label>
+            <label>Experience Gained <input id="skillExp" type="number" value="500" /></label>
+            <button id="trainSkillBtn">Train Skill</button>
+          </div>
+          <div>
+            <h3>Assign Ability</h3>
+            <label>Ability
+              <select id="abilitySelect"></select>
+            </label>
+            <button id="assignAbilityBtn">Assign Ability</button>
+          </div>
+        </div>
+        <pre id="setupOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>5. World</h2>
+        <div class="grid">
+          <div>
+            <h3>Enter Zone</h3>
+            <label>Zone
+              <select id="zoneId"></select>
+            </label>
+            <label>Position X <input id="positionX" type="number" value="100" /></label>
+            <label>Position Y <input id="positionY" type="number" value="100" /></label>
+            <button id="zoneEnterBtn">Enter</button>
+          </div>
+          <div>
+            <h3>World State</h3>
+            <button id="worldStateBtn">Refresh</button>
+          </div>
+        </div>
+        <pre id="worldOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>6. Inventory</h2>
+        <div class="grid">
+          <div>
+            <h3>View Inventory</h3>
+            <button id="inventoryBtn">Fetch Inventory</button>
+          </div>
+          <div>
+            <h3>Add Item</h3>
+            <label>Item Code <input id="addItemCode" type="text" value="IRON_ORE" /></label>
+            <label>Quantity <input id="addItemQty" type="number" value="5" /></label>
+            <button id="addItemBtn">Add Item</button>
+          </div>
+          <div>
+            <h3>Remove Item</h3>
+            <label>Item Code <input id="removeItemCode" type="text" value="IRON_ORE" /></label>
+            <label>Quantity <input id="removeItemQty" type="number" value="1" /></label>
+            <button id="removeItemBtn">Remove Item</button>
+          </div>
+        </div>
+        <pre id="inventoryOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>7. Gathering</h2>
+        <div class="grid">
+          <div>
+            <h3>List Nodes</h3>
+            <button id="listNodesBtn">Fetch Nodes</button>
+            <label>Node
+              <select id="nodeCode"></select>
+            </label>
+          </div>
+          <div>
+            <h3>Gather Attempt</h3>
+            <label>Client X <input id="clientX" type="number" value="112" /></label>
+            <label>Client Y <input id="clientY" type="number" value="92" /></label>
+            <button id="gatherBtn">Gather</button>
+          </div>
+        </div>
+        <pre id="gatheringOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>8. Combat</h2>
+        <div class="grid">
+          <div>
+            <h3>NPC List</h3>
+            <button id="listNpcBtn">Fetch NPCs</button>
+            <label>NPC
+              <select id="npcId"></select>
+            </label>
+          </div>
+          <div>
+            <h3>Attack</h3>
+            <label>Ability Code (optional)
+              <select id="abilityCode"></select>
+            </label>
+            <button id="attackBtn">Attack</button>
+          </div>
+          <div>
+            <h3>Revive</h3>
+            <button id="reviveBtn">Revive</button>
+          </div>
+        </div>
+        <pre id="combatOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>9. Loot</h2>
+        <div class="grid">
+          <div>
+            <h3>List Containers</h3>
+            <button id="listLootBtn">Fetch Containers</button>
+            <label>Container
+              <select id="containerId"></select>
+            </label>
+          </div>
+          <div>
+            <h3>Claim Container</h3>
+            <button id="claimLootBtn">Claim</button>
+          </div>
+        </div>
+        <pre id="lootOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>10. Betrayal</h2>
+        <div class="grid">
+          <div>
+            <h3>Start Betrayal</h3>
+            <label>Target Faction
+              <select id="betrayalTarget"></select>
+            </label>
+            <button id="betrayalStartBtn">Start</button>
+          </div>
+          <div>
+            <h3>Advance Step</h3>
+            <button id="betrayalAdvanceBtn">Advance</button>
+          </div>
+          <div>
+            <h3>Status</h3>
+            <button id="betrayalStatusBtn">Refresh</button>
+          </div>
+        </div>
+        <pre id="betrayalOutput"></pre>
+      </section>
+
+      <section class="card">
+        <h2>11. Reputation</h2>
+        <button id="reputationBtn">Fetch Reputation</button>
+        <pre id="reputationOutput"></pre>
+      </section>
+    </main>
+
+    <footer>
+      <p>Server authoritative checks: zone, range, cooldowns, ownership, and loot rules.</p>
+    </footer>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,126 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  --bg: #f6f7fb;
+  --card: #ffffff;
+  --text: #101828;
+  --muted: #667085;
+  --accent: #7b5cff;
+  --accent-soft: #edeaff;
+  --border: #e4e7ec;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+header {
+  padding: 2rem 1.5rem 1rem;
+  text-align: center;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin-top: 0.25rem;
+}
+
+main {
+  padding: 1rem;
+  display: grid;
+  gap: 1.25rem;
+  max-width: 1100px;
+  margin: 0 auto 2rem;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 16px;
+  padding: 1rem 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.08);
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 0.75rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+input,
+select {
+  padding: 0.5rem 0.6rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+  background: white;
+}
+
+button {
+  border: none;
+  border-radius: 10px;
+  background: var(--accent);
+  color: white;
+  padding: 0.55rem 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 0.2rem;
+}
+
+button:hover {
+  opacity: 0.9;
+}
+
+button.secondary {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 1px solid #d9d6ff;
+}
+
+pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 12px;
+  padding: 0.75rem;
+  font-size: 0.85rem;
+  max-height: 280px;
+  overflow: auto;
+}
+
+.pill {
+  margin-top: 0.5rem;
+  background: #f4f3ff;
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.8rem;
+  color: #6941c6;
+  display: inline-block;
+}
+
+.helper {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0.5rem 0 0;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response } from "express";
+import path from "node:path";
 import { Database } from "./db";
 import { createFactionsRouter } from "./routes/factions";
 import { createClassesRouter } from "./routes/classes";
@@ -9,11 +10,18 @@ import { createAuthRouter } from "./routes/auth";
 import { createWorldRouter } from "./routes/world";
 import { createInventoryRouter } from "./routes/inventory";
 import { createGatheringRouter } from "./routes/gathering";
+import { createCombatRouter } from "./routes/combat";
+import { createLootRouter } from "./routes/loot";
+import { createBetrayalRouter } from "./routes/betrayal";
+import { createReputationRouter } from "./routes/reputation";
 import { GameData } from "./data/gameData";
 
 export const createApp = (db: Database, gameData: GameData) => {
   const app = express();
   app.use(express.json());
+
+  const publicDir = path.resolve(process.cwd(), "public");
+  app.use(express.static(publicDir));
 
   app.get("/health", async (_req: Request, res: Response) => {
     const dbStatus = await db.connect();
@@ -35,6 +43,10 @@ export const createApp = (db: Database, gameData: GameData) => {
   app.use("/api/world", createWorldRouter(db));
   app.use("/api/inventory", createInventoryRouter(db, gameData));
   app.use("/api/gathering", createGatheringRouter(db, gameData));
+  app.use("/api/combat", createCombatRouter(db));
+  app.use("/api/loot", createLootRouter(db, gameData));
+  app.use("/api/betrayal", createBetrayalRouter(db));
+  app.use("/api/reputation", createReputationRouter(db));
 
   return app;
 };

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,72 @@
+import { Request, Response, NextFunction } from "express";
+import { Database } from "../db";
+import { PlayerSession } from "../types";
+import { sendError } from "../utils/errors";
+
+const getBearerToken = (req: Request): string | null => {
+  const header = req.header("authorization");
+  if (!header) {
+    return null;
+  }
+
+  const [scheme, value] = header.split(" ");
+  if (scheme !== "Bearer" || !value) {
+    return null;
+  }
+
+  return value;
+};
+
+export interface AuthenticatedLocals {
+  player: {
+    id: number;
+    email: string;
+    display_name: string;
+  };
+}
+
+export const requireSession = (db: Database) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const token = getBearerToken(req);
+    if (!token) {
+      sendError(res, 401, "UNAUTHORIZED", "Missing or invalid session token.");
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const sessionResult = await pool.query<
+        PlayerSession & { email: string; display_name: string }
+      >(
+        `SELECT ps.id, ps.player_id, ps.token, ps.created_at, ps.expires_at,
+                p.email, p.display_name
+         FROM player_sessions ps
+         JOIN players p ON ps.player_id = p.id
+         WHERE ps.token = $1`,
+        [token]
+      );
+
+      if (sessionResult.rows.length === 0) {
+        sendError(res, 401, "UNAUTHORIZED", "Session not found.");
+        return;
+      }
+
+      const session = sessionResult.rows[0];
+      if (new Date(session.expires_at).getTime() <= Date.now()) {
+        sendError(res, 401, "SESSION_EXPIRED", "Session has expired.");
+        return;
+      }
+
+      res.locals.player = {
+        id: session.player_id,
+        email: session.email,
+        display_name: session.display_name,
+      } satisfies AuthenticatedLocals["player"];
+
+      next();
+    } catch (error) {
+      console.error("Error validating session:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to validate session.");
+    }
+  };
+};

--- a/src/routes/betrayal.ts
+++ b/src/routes/betrayal.ts
@@ -1,0 +1,237 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { Database } from "../db";
+import { requireSession } from "../middleware/auth";
+import { sendError } from "../utils/errors";
+import { Character, BetrayalQuest } from "../types";
+
+const startSchema = z.object({
+  character_id: z.number().int().positive(),
+  target_faction_id: z.number().int().positive(),
+});
+
+const advanceSchema = z.object({
+  character_id: z.number().int().positive(),
+});
+
+const statusParamsSchema = z.object({
+  characterId: z.coerce.number().int().positive(),
+});
+
+const STEP_SEQUENCE: BetrayalQuest["current_step"][] = [
+  "RENOUNCE",
+  "PROVE",
+  "COMPLETE",
+];
+
+const BETRAYAL_REP_PENALTY = -500;
+const BETRAYAL_REP_BASELINE = 200;
+
+export const createBetrayalRouter = (db: Database) => {
+  const router = Router();
+
+  router.use(requireSession(db));
+
+  router.get("/status/:characterId", async (req: Request, res: Response) => {
+    const parsed = statusParamsSchema.safeParse(req.params);
+    if (!parsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid character id.", parsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const player = res.locals.player as { id: number };
+      const characterId = parsed.data.characterId;
+
+      const characterResult = await pool.query<Character>(
+        "SELECT id FROM characters WHERE id = $1 AND player_id = $2",
+        [characterId, player.id]
+      );
+      if (characterResult.rows.length === 0) {
+        sendError(res, 404, "CHARACTER_NOT_FOUND", "Character not found.");
+        return;
+      }
+
+      const questResult = await pool.query<BetrayalQuest>(
+        "SELECT * FROM betrayal_quests WHERE character_id = $1 ORDER BY started_at DESC LIMIT 1",
+        [characterId]
+      );
+
+      res.json({
+        character_id: characterId,
+        quest: questResult.rows[0] ?? null,
+      });
+    } catch (error) {
+      console.error("Error fetching betrayal status:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to fetch betrayal status.");
+    }
+  });
+
+  router.post("/start", async (req: Request, res: Response) => {
+    const parsed = startSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid betrayal payload.", parsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const player = res.locals.player as { id: number };
+      const { character_id, target_faction_id } = parsed.data;
+
+      const characterResult = await pool.query<Character>(
+        "SELECT id, faction_id FROM characters WHERE id = $1 AND player_id = $2",
+        [character_id, player.id]
+      );
+      if (characterResult.rows.length === 0) {
+        sendError(res, 404, "CHARACTER_NOT_FOUND", "Character not found.");
+        return;
+      }
+
+      const character = characterResult.rows[0];
+      if (character.faction_id === target_faction_id) {
+        sendError(res, 400, "INVALID_TARGET", "Target faction must differ from current faction.");
+        return;
+      }
+
+      const activeQuest = await pool.query<BetrayalQuest>(
+        `SELECT * FROM betrayal_quests
+         WHERE character_id = $1 AND status = 'IN_PROGRESS'
+         ORDER BY started_at DESC
+         LIMIT 1`,
+        [character_id]
+      );
+
+      if (activeQuest.rows.length > 0) {
+        sendError(res, 400, "QUEST_ACTIVE", "Betrayal quest already in progress.");
+        return;
+      }
+
+      const questResult = await pool.query<BetrayalQuest>(
+        `INSERT INTO betrayal_quests (character_id, target_faction_id, current_step, status)
+         VALUES ($1, $2, 'RENOUNCE', 'IN_PROGRESS')
+         RETURNING *`,
+        [character_id, target_faction_id]
+      );
+
+      res.status(201).json({
+        quest: questResult.rows[0],
+      });
+    } catch (error) {
+      console.error("Error starting betrayal quest:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to start betrayal quest.");
+    }
+  });
+
+  router.post("/advance", async (req: Request, res: Response) => {
+    const parsed = advanceSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid betrayal payload.", parsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const player = res.locals.player as { id: number };
+      const { character_id } = parsed.data;
+
+      const characterResult = await pool.query<Character>(
+        "SELECT id, faction_id FROM characters WHERE id = $1 AND player_id = $2",
+        [character_id, player.id]
+      );
+      if (characterResult.rows.length === 0) {
+        sendError(res, 404, "CHARACTER_NOT_FOUND", "Character not found.");
+        return;
+      }
+
+      const questResult = await pool.query<BetrayalQuest>(
+        `SELECT * FROM betrayal_quests
+         WHERE character_id = $1 AND status = 'IN_PROGRESS'
+         ORDER BY started_at DESC
+         LIMIT 1`,
+        [character_id]
+      );
+
+      if (questResult.rows.length === 0) {
+        sendError(res, 404, "QUEST_NOT_FOUND", "No active betrayal quest.");
+        return;
+      }
+
+      const quest = questResult.rows[0];
+      const currentIndex = STEP_SEQUENCE.indexOf(quest.current_step);
+      const nextStep = STEP_SEQUENCE[currentIndex + 1] ?? "COMPLETE";
+
+      const client = await pool.connect();
+
+      try {
+        await client.query("BEGIN");
+
+        if (quest.current_step === "PROVE") {
+          await client.query(
+            `UPDATE betrayal_quests
+             SET current_step = 'COMPLETE', status = 'COMPLETED', updated_at = CURRENT_TIMESTAMP
+             WHERE id = $1`,
+            [quest.id]
+          );
+
+          await client.query(
+            `UPDATE characters
+             SET faction_id = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2`,
+            [quest.target_faction_id, character_id]
+          );
+
+          await client.query(
+            `UPDATE character_reputation
+             SET value = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE character_id = $2`,
+            [BETRAYAL_REP_BASELINE, character_id]
+          );
+
+          await client.query(
+            `UPDATE character_reputation
+             SET value = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE character_id = $2 AND faction_id = $3`,
+            [BETRAYAL_REP_PENALTY, character_id, characterResult.rows[0].faction_id]
+          );
+
+          await client.query(
+            `UPDATE character_reputation
+             SET value = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE character_id = $2 AND faction_id = $3`,
+            [BETRAYAL_REP_BASELINE + 200, character_id, quest.target_faction_id]
+          );
+        } else {
+          await client.query(
+            `UPDATE betrayal_quests
+             SET current_step = $1, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2`,
+            [nextStep, quest.id]
+          );
+        }
+
+        const updatedQuest = await client.query<BetrayalQuest>(
+          "SELECT * FROM betrayal_quests WHERE id = $1",
+          [quest.id]
+        );
+
+        await client.query("COMMIT");
+
+        res.json({
+          quest: updatedQuest.rows[0],
+        });
+      } catch (error) {
+        await client.query("ROLLBACK");
+        throw error;
+      } finally {
+        client.release();
+      }
+    } catch (error) {
+      console.error("Error advancing betrayal quest:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to advance betrayal quest.");
+    }
+  });
+
+  return router;
+};

--- a/src/routes/combat.ts
+++ b/src/routes/combat.ts
@@ -1,0 +1,498 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { Database } from "../db";
+import { requireSession } from "../middleware/auth";
+import { createRateLimiter } from "../middleware/rateLimit";
+import {
+  Character,
+  CharacterPosition,
+  CharacterState,
+  NpcSpawn,
+  Zone,
+} from "../types";
+import { sendError } from "../utils/errors";
+import { logSuspiciousAction } from "../utils/securityLog";
+import { calculateDeathDrops } from "../utils/loot";
+
+const listNpcsSchema = z.object({
+  zoneId: z.coerce.number().int().positive(),
+});
+
+const attackSchema = z.object({
+  character_id: z.number().int().positive(),
+  npc_id: z.number().int().positive(),
+  ability_code: z.string().min(2).max(64).optional(),
+});
+
+const reviveSchema = z.object({
+  character_id: z.number().int().positive(),
+});
+
+const parseNumeric = (value: number | string) => Number(value);
+
+const BASE_DAMAGE = 10;
+const BASE_ATTACK_RANGE = 12;
+
+const logCombatSuspicious = (
+  req: Request,
+  playerId: number,
+  characterId: number,
+  zoneId: number,
+  reason: string
+) => {
+  logSuspiciousAction(req, {
+    player_id: playerId,
+    character_id: characterId,
+    zone_id: zoneId,
+    action: "COMBAT",
+    reason,
+  });
+};
+
+export const createCombatRouter = (db: Database) => {
+  const router = Router();
+
+  const attackLimiter = createRateLimiter({ windowMs: 30_000, max: 20 });
+
+  router.use(requireSession(db));
+
+  router.get("/npcs/:zoneId", async (req: Request, res: Response) => {
+    const parsed = listNpcsSchema.safeParse(req.params);
+    if (!parsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid zone id.", parsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const { zoneId } = parsed.data;
+      const now = new Date();
+
+      const spawnsResult = await pool.query<
+        NpcSpawn & {
+          template_code: string;
+          template_name: string;
+          base_hp: number;
+          base_damage: number;
+        }
+      >(
+        `SELECT ns.*, nt.code as template_code, nt.name as template_name, nt.base_hp, nt.base_damage
+         FROM npc_spawns ns
+         JOIN npc_templates nt ON ns.template_id = nt.id
+         WHERE ns.zone_id = $1
+         ORDER BY ns.id`,
+        [zoneId]
+      );
+
+      const spawns = [] as Array<{
+        id: number;
+        code: string;
+        name: string;
+        zone_id: number;
+        position: { x: number; y: number };
+        current_hp: number;
+        max_hp: number;
+        base_damage: number;
+        respawn_seconds: number;
+        is_alive: boolean;
+      }>;
+
+      for (const spawn of spawnsResult.rows) {
+        const currentHp = parseNumeric(spawn.current_hp);
+        const maxHp = spawn.base_hp;
+        const isAlive = currentHp > 0;
+
+        if (!isAlive && spawn.last_defeated_at) {
+          const respawnAt = new Date(spawn.last_defeated_at).getTime() + spawn.respawn_seconds * 1000;
+          if (now.getTime() >= respawnAt) {
+            const updated = await pool.query<NpcSpawn>(
+              `UPDATE npc_spawns
+               SET current_hp = $1, last_defeated_at = NULL, updated_at = CURRENT_TIMESTAMP
+               WHERE id = $2
+               RETURNING *`,
+              [maxHp, spawn.id]
+            );
+            const refreshed = updated.rows[0];
+            spawns.push({
+              id: refreshed.id,
+              code: spawn.template_code,
+              name: spawn.template_name,
+              zone_id: refreshed.zone_id,
+              position: {
+                x: parseNumeric(refreshed.position_x),
+                y: parseNumeric(refreshed.position_y),
+              },
+              current_hp: parseNumeric(refreshed.current_hp),
+              max_hp: maxHp,
+              base_damage: spawn.base_damage,
+              respawn_seconds: refreshed.respawn_seconds,
+              is_alive: parseNumeric(refreshed.current_hp) > 0,
+            });
+            continue;
+          }
+        }
+
+        spawns.push({
+          id: spawn.id,
+          code: spawn.template_code,
+          name: spawn.template_name,
+          zone_id: spawn.zone_id,
+          position: {
+            x: parseNumeric(spawn.position_x),
+            y: parseNumeric(spawn.position_y),
+          },
+          current_hp: currentHp,
+          max_hp: maxHp,
+          base_damage: spawn.base_damage,
+          respawn_seconds: spawn.respawn_seconds,
+          is_alive: isAlive,
+        });
+      }
+
+      res.json({
+        zone_id: zoneId,
+        npcs: spawns,
+        server_time: now.toISOString(),
+      });
+    } catch (error) {
+      console.error("Error listing NPCs:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to fetch NPCs.");
+    }
+  });
+
+  router.post("/attack", attackLimiter, async (req: Request, res: Response) => {
+    const parsed = attackSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid combat payload.", parsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    const { character_id, npc_id, ability_code } = parsed.data;
+
+    try {
+      const pool = db.getPool();
+      const player = res.locals.player as { id: number };
+      const client = await pool.connect();
+
+      try {
+        await client.query("BEGIN");
+
+        const characterResult = await client.query<Character>(
+          "SELECT * FROM characters WHERE id = $1 AND player_id = $2",
+          [character_id, player.id]
+        );
+        if (characterResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 404, "CHARACTER_NOT_FOUND", "Character not found.");
+          return;
+        }
+        const character = characterResult.rows[0];
+
+        const stateResult = await client.query<CharacterState>(
+          "SELECT * FROM character_state WHERE character_id = $1",
+          [character_id]
+        );
+        if (stateResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 404, "CHARACTER_STATE_MISSING", "Character state missing.");
+          return;
+        }
+        const state = stateResult.rows[0];
+        if (state.is_dead) {
+          await client.query("ROLLBACK");
+          sendError(res, 400, "CHARACTER_DEAD", "Character must be revived before fighting.");
+          return;
+        }
+
+        const positionResult = await client.query<CharacterPosition>(
+          "SELECT * FROM character_positions WHERE character_id = $1",
+          [character_id]
+        );
+        if (positionResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 404, "CHARACTER_NOT_IN_WORLD", "Character has no active world state.");
+          return;
+        }
+        const position = positionResult.rows[0];
+        const serverPosition = {
+          x: parseNumeric(position.position_x),
+          y: parseNumeric(position.position_y),
+        };
+
+        const npcResult = await client.query<
+          NpcSpawn & {
+            template_code: string;
+            template_name: string;
+            base_hp: number;
+            base_damage: number;
+          }
+        >(
+          `SELECT ns.*, nt.code as template_code, nt.name as template_name, nt.base_hp, nt.base_damage
+           FROM npc_spawns ns
+           JOIN npc_templates nt ON ns.template_id = nt.id
+           WHERE ns.id = $1`,
+          [npc_id]
+        );
+
+        if (npcResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 404, "NPC_NOT_FOUND", "NPC not found.");
+          return;
+        }
+
+        const npc = npcResult.rows[0];
+        if (npc.zone_id !== position.zone_id) {
+          await client.query("ROLLBACK");
+          logCombatSuspicious(req, player.id, character_id, position.zone_id, "ZONE_MISMATCH");
+          sendError(res, 400, "INVALID_ZONE", "NPC is not in the same zone.");
+          return;
+        }
+
+        const npcPosition = {
+          x: parseNumeric(npc.position_x),
+          y: parseNumeric(npc.position_y),
+        };
+        const distance = Math.hypot(npcPosition.x - serverPosition.x, npcPosition.y - serverPosition.y);
+        if (distance > BASE_ATTACK_RANGE) {
+          await client.query("ROLLBACK");
+          logCombatSuspicious(req, player.id, character_id, position.zone_id, "OUT_OF_RANGE");
+          sendError(res, 400, "OUT_OF_RANGE", "Target is out of range.");
+          return;
+        }
+
+        let npcCurrentHp = parseNumeric(npc.current_hp);
+        if (npcCurrentHp <= 0) {
+          if (npc.last_defeated_at) {
+            const respawnAt = new Date(npc.last_defeated_at).getTime() + npc.respawn_seconds * 1000;
+            if (Date.now() < respawnAt) {
+              await client.query("ROLLBACK");
+              sendError(res, 400, "NPC_DEFEATED", "NPC is waiting to respawn.");
+              return;
+            }
+          }
+          npcCurrentHp = npc.base_hp;
+        }
+
+        let abilityModifier = 1;
+        let cooldownSeconds = 0;
+        let abilityId: number | null = null;
+
+        if (ability_code) {
+          const abilityResult = await client.query<
+            { id: number; cooldown_seconds: number; damage_modifier: number }
+          >(
+            `SELECT a.id, a.cooldown_seconds, a.damage_modifier
+             FROM abilities a
+             JOIN character_abilities ca ON a.id = ca.ability_id
+             WHERE ca.character_id = $1 AND a.code = $2`,
+            [character_id, ability_code]
+          );
+
+          if (abilityResult.rows.length === 0) {
+            await client.query("ROLLBACK");
+            sendError(res, 400, "ABILITY_NOT_OWNED", "Character does not have this ability.");
+            return;
+          }
+
+          const ability = abilityResult.rows[0];
+          abilityModifier = ability.damage_modifier;
+          cooldownSeconds = ability.cooldown_seconds;
+          abilityId = ability.id;
+
+          const cooldownResult = await client.query<{ last_used_at: Date }>(
+            `SELECT last_used_at
+             FROM character_ability_cooldowns
+             WHERE character_id = $1 AND ability_id = $2`,
+            [character_id, abilityId]
+          );
+
+          if (cooldownResult.rows.length > 0) {
+            const lastUsed = cooldownResult.rows[0].last_used_at;
+            const nextAvailable = new Date(lastUsed).getTime() + cooldownSeconds * 1000;
+            if (Date.now() < nextAvailable) {
+              await client.query("ROLLBACK");
+              sendError(res, 400, "ABILITY_COOLDOWN", "Ability is on cooldown.");
+              return;
+            }
+          }
+        }
+
+        const baseDamage = BASE_DAMAGE + character.power * 2;
+        const damage = Math.max(1, Math.floor(baseDamage * abilityModifier));
+        const npcRemainingHp = Math.max(0, npcCurrentHp - damage);
+
+        await client.query(
+          `UPDATE npc_spawns
+           SET current_hp = $1,
+               last_defeated_at = CASE WHEN $1 = 0 THEN CURRENT_TIMESTAMP ELSE last_defeated_at END,
+               updated_at = CURRENT_TIMESTAMP
+           WHERE id = $2`,
+          [npcRemainingHp, npc.id]
+        );
+
+        if (abilityId) {
+          await client.query(
+            `INSERT INTO character_ability_cooldowns (character_id, ability_id, last_used_at)
+             VALUES ($1, $2, CURRENT_TIMESTAMP)
+             ON CONFLICT (character_id, ability_id)
+             DO UPDATE SET last_used_at = EXCLUDED.last_used_at, updated_at = CURRENT_TIMESTAMP`,
+            [character_id, abilityId]
+          );
+        }
+
+        let characterRemainingHp = state.current_hp;
+        let deathPayload: {
+          dropped_items: Array<{ item_code: string; quantity: number }>;
+          loot_container_id: number | null;
+        } | null = null;
+
+        if (npcRemainingHp > 0) {
+          characterRemainingHp = Math.max(0, state.current_hp - npc.base_damage);
+
+          await client.query(
+            `UPDATE character_state
+             SET current_hp = $1, is_dead = $2, updated_at = CURRENT_TIMESTAMP
+             WHERE character_id = $3`,
+            [characterRemainingHp, characterRemainingHp === 0, character_id]
+          );
+        }
+
+        if (characterRemainingHp === 0) {
+          const zoneResult = await client.query<Zone>(
+            "SELECT * FROM zones WHERE id = $1",
+            [position.zone_id]
+          );
+          const zone = zoneResult.rows[0];
+
+          const inventoryResult = await client.query<{ item_code: string; quantity: number }>(
+            "SELECT item_code, quantity FROM character_inventory WHERE character_id = $1",
+            [character_id]
+          );
+
+          const { dropped, remaining } = calculateDeathDrops(
+            inventoryResult.rows.map((row) => ({
+              item_code: row.item_code,
+              quantity: row.quantity,
+            })),
+            zone.loot_drop_on_death
+          );
+
+          let lootContainerId: number | null = null;
+          if (dropped.length > 0) {
+            const containerResult = await client.query<{ id: number }>(
+              `INSERT INTO loot_containers (zone_id, position_x, position_y, owner_character_id)
+               VALUES ($1, $2, $3, $4)
+               RETURNING id`,
+              [position.zone_id, serverPosition.x, serverPosition.y, character_id]
+            );
+            lootContainerId = containerResult.rows[0].id;
+
+            for (const item of dropped) {
+              await client.query(
+                `INSERT INTO loot_container_items (container_id, item_code, quantity)
+                 VALUES ($1, $2, $3)`,
+                [lootContainerId, item.item_code, item.quantity]
+              );
+            }
+          }
+
+          await client.query("DELETE FROM character_inventory WHERE character_id = $1", [character_id]);
+
+          for (const item of remaining) {
+            await client.query(
+              `INSERT INTO character_inventory (character_id, item_code, quantity)
+               VALUES ($1, $2, $3)
+               ON CONFLICT (character_id, item_code)
+               DO UPDATE SET quantity = EXCLUDED.quantity, updated_at = CURRENT_TIMESTAMP`,
+              [character_id, item.item_code, item.quantity]
+            );
+          }
+
+          deathPayload = {
+            dropped_items: dropped,
+            loot_container_id: lootContainerId,
+          };
+        }
+
+        await client.query("COMMIT");
+
+        res.json({
+          character: {
+            id: character.id,
+            current_hp: characterRemainingHp,
+            max_hp: state.max_hp,
+            is_dead: characterRemainingHp === 0,
+          },
+          npc: {
+            id: npc.id,
+            code: npc.template_code,
+            name: npc.template_name,
+            current_hp: npcRemainingHp,
+            max_hp: npc.base_hp,
+            is_alive: npcRemainingHp > 0,
+          },
+          damage,
+          retaliated_damage: npcRemainingHp > 0 ? npc.base_damage : 0,
+          death: deathPayload,
+          server_time: new Date().toISOString(),
+        });
+      } catch (error) {
+        await client.query("ROLLBACK");
+        throw error;
+      } finally {
+        client.release();
+      }
+    } catch (error) {
+      console.error("Error resolving combat:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to resolve combat.");
+    }
+  });
+
+  router.post("/revive", async (req: Request, res: Response) => {
+    const parsed = reviveSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid revive payload.", parsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const player = res.locals.player as { id: number };
+      const { character_id } = parsed.data;
+
+      const characterResult = await pool.query<Character>(
+        "SELECT id FROM characters WHERE id = $1 AND player_id = $2",
+        [character_id, player.id]
+      );
+      if (characterResult.rows.length === 0) {
+        sendError(res, 404, "CHARACTER_NOT_FOUND", "Character not found.");
+        return;
+      }
+
+      const stateResult = await pool.query<CharacterState>(
+        `UPDATE character_state
+         SET current_hp = max_hp, is_dead = FALSE, updated_at = CURRENT_TIMESTAMP
+         WHERE character_id = $1
+         RETURNING *`,
+        [character_id]
+      );
+
+      if (stateResult.rows.length === 0) {
+        sendError(res, 404, "CHARACTER_STATE_MISSING", "Character state missing.");
+        return;
+      }
+
+      res.json({
+        character_id,
+        current_hp: stateResult.rows[0].current_hp,
+        max_hp: stateResult.rows[0].max_hp,
+        is_dead: stateResult.rows[0].is_dead,
+      });
+    } catch (error) {
+      console.error("Error reviving character:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to revive character.");
+    }
+  });
+
+  return router;
+};

--- a/src/routes/loot.ts
+++ b/src/routes/loot.ts
@@ -1,0 +1,313 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { Database } from "../db";
+import { GameData } from "../data/gameData";
+import { requireSession } from "../middleware/auth";
+import { createRateLimiter } from "../middleware/rateLimit";
+import { Character, CharacterPosition, CharacterState, LootContainer } from "../types";
+import { sendError } from "../utils/errors";
+import { logSuspiciousAction } from "../utils/securityLog";
+
+const listContainersSchema = z.object({
+  characterId: z.coerce.number().int().positive(),
+});
+
+const claimParamsSchema = z.object({
+  containerId: z.coerce.number().int().positive(),
+});
+
+const claimBodySchema = z.object({
+  character_id: z.number().int().positive(),
+});
+
+const parseNumeric = (value: number | string) => Number(value);
+
+const logLootSuspicious = (
+  req: Request,
+  playerId: number,
+  characterId: number,
+  zoneId: number,
+  reason: string
+) => {
+  logSuspiciousAction(req, {
+    player_id: playerId,
+    character_id: characterId,
+    zone_id: zoneId,
+    action: "LOOT",
+    reason,
+  });
+};
+
+export const createLootRouter = (db: Database, gameData: GameData) => {
+  const router = Router();
+
+  const claimLimiter = createRateLimiter({ windowMs: 30_000, max: 20 });
+
+  router.use(requireSession(db));
+
+  router.get("/containers/:characterId", async (req: Request, res: Response) => {
+    const parsed = listContainersSchema.safeParse(req.params);
+    if (!parsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid character id.", parsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const player = res.locals.player as { id: number };
+      const characterId = parsed.data.characterId;
+
+      const characterResult = await pool.query<Character>(
+        "SELECT id FROM characters WHERE id = $1 AND player_id = $2",
+        [characterId, player.id]
+      );
+      if (characterResult.rows.length === 0) {
+        sendError(res, 404, "CHARACTER_NOT_FOUND", "Character not found.");
+        return;
+      }
+
+      const positionResult = await pool.query<CharacterPosition>(
+        "SELECT * FROM character_positions WHERE character_id = $1",
+        [characterId]
+      );
+      if (positionResult.rows.length === 0) {
+        sendError(res, 404, "CHARACTER_NOT_IN_WORLD", "Character has no active world state.");
+        return;
+      }
+
+      const position = positionResult.rows[0];
+      const zoneId = position.zone_id;
+
+      const containersResult = await pool.query<LootContainer>(
+        `SELECT * FROM loot_containers
+         WHERE zone_id = $1
+         ORDER BY created_at DESC`,
+        [zoneId]
+      );
+
+      const containerIds = containersResult.rows.map((container) => container.id);
+      const itemsResult = containerIds.length
+        ? await pool.query<{
+            container_id: number;
+            item_code: string;
+            quantity: number;
+          }>(
+            `SELECT container_id, item_code, quantity
+             FROM loot_container_items
+             WHERE container_id = ANY($1::int[])
+             ORDER BY item_code`,
+            [containerIds]
+          )
+        : { rows: [] };
+
+      const itemsByContainer = new Map<number, Array<{ item_code: string; quantity: number }>>();
+      for (const item of itemsResult.rows) {
+        const list = itemsByContainer.get(item.container_id) ?? [];
+        list.push({ item_code: item.item_code, quantity: item.quantity });
+        itemsByContainer.set(item.container_id, list);
+      }
+
+      const containers = containersResult.rows.map((container) => ({
+        id: container.id,
+        zone_id: container.zone_id,
+        position: {
+          x: parseNumeric(container.position_x),
+          y: parseNumeric(container.position_y),
+        },
+        owner_character_id: container.owner_character_id,
+        items: (itemsByContainer.get(container.id) ?? []).map((entry) => ({
+          ...entry,
+          item: gameData.items[entry.item_code],
+        })),
+        created_at: container.created_at,
+      }));
+
+      res.json({
+        character_id: characterId,
+        zone_id: zoneId,
+        containers,
+      });
+    } catch (error) {
+      console.error("Error listing loot containers:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to fetch loot containers.");
+    }
+  });
+
+  router.post("/containers/:containerId/claim", claimLimiter, async (req: Request, res: Response) => {
+    const paramsParsed = claimParamsSchema.safeParse(req.params);
+    if (!paramsParsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid container id.", paramsParsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    const bodyParsed = claimBodySchema.safeParse(req.body);
+    if (!bodyParsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid loot claim payload.", bodyParsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const player = res.locals.player as { id: number };
+      const { containerId } = paramsParsed.data;
+      const { character_id } = bodyParsed.data;
+
+      const client = await pool.connect();
+
+      try {
+        await client.query("BEGIN");
+
+        const characterResult = await client.query<Character>(
+          "SELECT id FROM characters WHERE id = $1 AND player_id = $2",
+          [character_id, player.id]
+        );
+        if (characterResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 404, "CHARACTER_NOT_FOUND", "Character not found.");
+          return;
+        }
+
+        const stateResult = await client.query<CharacterState>(
+          "SELECT * FROM character_state WHERE character_id = $1",
+          [character_id]
+        );
+        if (stateResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 404, "CHARACTER_STATE_MISSING", "Character state missing.");
+          return;
+        }
+        if (stateResult.rows[0].is_dead) {
+          await client.query("ROLLBACK");
+          sendError(res, 400, "CHARACTER_DEAD", "Character cannot loot while dead.");
+          return;
+        }
+
+        const positionResult = await client.query<CharacterPosition>(
+          "SELECT * FROM character_positions WHERE character_id = $1",
+          [character_id]
+        );
+        if (positionResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 404, "CHARACTER_NOT_IN_WORLD", "Character has no active world state.");
+          return;
+        }
+
+        const containerResult = await client.query<LootContainer>(
+          "SELECT * FROM loot_containers WHERE id = $1",
+          [containerId]
+        );
+        if (containerResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 404, "CONTAINER_NOT_FOUND", "Loot container not found.");
+          return;
+        }
+
+        const container = containerResult.rows[0];
+        const position = positionResult.rows[0];
+        const zoneId = position.zone_id;
+
+        if (container.zone_id !== zoneId) {
+          await client.query("ROLLBACK");
+          logLootSuspicious(req, player.id, character_id, zoneId, "ZONE_MISMATCH");
+          sendError(res, 400, "INVALID_ZONE", "Loot container is not in the same zone.");
+          return;
+        }
+
+        const characterPosition = {
+          x: parseNumeric(position.position_x),
+          y: parseNumeric(position.position_y),
+        };
+        const containerPosition = {
+          x: parseNumeric(container.position_x),
+          y: parseNumeric(container.position_y),
+        };
+        const distance = Math.hypot(
+          containerPosition.x - characterPosition.x,
+          containerPosition.y - characterPosition.y
+        );
+        if (distance > 12) {
+          await client.query("ROLLBACK");
+          logLootSuspicious(req, player.id, character_id, zoneId, "OUT_OF_RANGE");
+          sendError(res, 400, "OUT_OF_RANGE", "Loot container is out of range.");
+          return;
+        }
+
+        const itemsResult = await client.query<{
+          item_code: string;
+          quantity: number;
+        }>(
+          "SELECT item_code, quantity FROM loot_container_items WHERE container_id = $1",
+          [containerId]
+        );
+
+        if (itemsResult.rows.length === 0) {
+          await client.query("ROLLBACK");
+          sendError(res, 400, "EMPTY_CONTAINER", "Loot container is empty.");
+          return;
+        }
+
+        for (const item of itemsResult.rows) {
+          const itemDef = gameData.items[item.item_code];
+          if (!itemDef) {
+            await client.query("ROLLBACK");
+            sendError(res, 500, "INVALID_LOOT", "Loot item definition missing.");
+            return;
+          }
+
+          const inventoryResult = await client.query<{ quantity: number }>(
+            "SELECT quantity FROM character_inventory WHERE character_id = $1 AND item_code = $2",
+            [character_id, item.item_code]
+          );
+
+          const existingQuantity = inventoryResult.rows[0]?.quantity ?? 0;
+          const newQuantity = existingQuantity + item.quantity;
+          if (newQuantity > itemDef.stack_limit) {
+            await client.query("ROLLBACK");
+            sendError(
+              res,
+              400,
+              "STACK_LIMIT_EXCEEDED",
+              `Stack limit exceeded for ${item.item_code}. Max ${itemDef.stack_limit}.`
+            );
+            return;
+          }
+        }
+
+        for (const item of itemsResult.rows) {
+          await client.query(
+            `INSERT INTO character_inventory (character_id, item_code, quantity)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (character_id, item_code)
+             DO UPDATE SET quantity = character_inventory.quantity + $3, updated_at = CURRENT_TIMESTAMP`,
+            [character_id, item.item_code, item.quantity]
+          );
+        }
+
+        await client.query("DELETE FROM loot_container_items WHERE container_id = $1", [containerId]);
+        await client.query("DELETE FROM loot_containers WHERE id = $1", [containerId]);
+
+        await client.query("COMMIT");
+
+        res.json({
+          character_id,
+          container_id: containerId,
+          items: itemsResult.rows.map((item) => ({
+            item_code: item.item_code,
+            quantity: item.quantity,
+            item: gameData.items[item.item_code],
+          })),
+        });
+      } catch (error) {
+        await client.query("ROLLBACK");
+        throw error;
+      } finally {
+        client.release();
+      }
+    } catch (error) {
+      console.error("Error claiming loot:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to claim loot.");
+    }
+  });
+
+  return router;
+};

--- a/src/routes/reputation.ts
+++ b/src/routes/reputation.ts
@@ -1,0 +1,70 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { Database } from "../db";
+import { requireSession } from "../middleware/auth";
+import { sendError } from "../utils/errors";
+import { Character, CharacterReputation, Faction } from "../types";
+
+const paramsSchema = z.object({
+  characterId: z.coerce.number().int().positive(),
+});
+
+export const createReputationRouter = (db: Database) => {
+  const router = Router();
+
+  router.use(requireSession(db));
+
+  router.get("/:characterId", async (req: Request, res: Response) => {
+    const parsed = paramsSchema.safeParse(req.params);
+    if (!parsed.success) {
+      sendError(res, 400, "INVALID_INPUT", "Invalid character id.", parsed.error.flatten().fieldErrors);
+      return;
+    }
+
+    try {
+      const pool = db.getPool();
+      const player = res.locals.player as { id: number };
+      const characterId = parsed.data.characterId;
+
+      const characterResult = await pool.query<Character>(
+        "SELECT id FROM characters WHERE id = $1 AND player_id = $2",
+        [characterId, player.id]
+      );
+      if (characterResult.rows.length === 0) {
+        sendError(res, 404, "CHARACTER_NOT_FOUND", "Character not found.");
+        return;
+      }
+
+      const reputationResult = await pool.query<
+        CharacterReputation & { faction_name: string; faction_code: string }
+      >(
+        `SELECT cr.character_id, cr.faction_id, cr.value, cr.updated_at,
+                f.name as faction_name, f.code as faction_code
+         FROM character_reputation cr
+         JOIN factions f ON cr.faction_id = f.id
+         WHERE cr.character_id = $1
+         ORDER BY f.id`,
+        [characterId]
+      );
+
+      res.json({
+        character_id: characterId,
+        reputation: reputationResult.rows.map((row) => ({
+          character_id: row.character_id,
+          faction: {
+            id: row.faction_id,
+            name: row.faction_name,
+            code: row.faction_code,
+          } satisfies Pick<Faction, "id" | "name" | "code">,
+          value: row.value,
+          updated_at: row.updated_at,
+        })),
+      });
+    } catch (error) {
+      console.error("Error fetching reputation:", error);
+      sendError(res, 500, "INTERNAL_ERROR", "Failed to fetch reputation.");
+    }
+  });
+
+  return router;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface Zone {
 
 export interface Character {
   id: number;
+  player_id: number;
   name: string;
   faction_id: number;
   class_id: number;
@@ -54,6 +55,14 @@ export interface CharacterPosition {
   zone_id: number;
   position_x: number | string;
   position_y: number | string;
+  updated_at: Date;
+}
+
+export interface CharacterState {
+  character_id: number;
+  current_hp: number;
+  max_hp: number;
+  is_dead: boolean;
   updated_at: Date;
 }
 
@@ -152,6 +161,72 @@ export interface CharacterSkill {
 export interface SkillWithLevel extends Skill {
   current_level: number;
   experience: number;
+}
+
+export interface NpcTemplate {
+  id: number;
+  code: string;
+  name: string;
+  base_hp: number;
+  base_damage: number;
+  created_at: Date;
+}
+
+export interface NpcSpawn {
+  id: number;
+  template_id: number;
+  zone_id: number;
+  position_x: number | string;
+  position_y: number | string;
+  current_hp: number;
+  respawn_seconds: number;
+  last_defeated_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface CharacterAbilityCooldown {
+  character_id: number;
+  ability_id: number;
+  last_used_at: Date;
+  updated_at: Date;
+}
+
+export interface LootContainer {
+  id: number;
+  zone_id: number;
+  position_x: number | string;
+  position_y: number | string;
+  owner_character_id: number | null;
+  created_at: Date;
+}
+
+export interface LootContainerItem {
+  id: number;
+  container_id: number;
+  item_code: string;
+  quantity: number;
+  created_at: Date;
+}
+
+export interface CharacterReputation {
+  character_id: number;
+  faction_id: number;
+  value: number;
+  updated_at: Date;
+}
+
+export type BetrayalStatus = "IN_PROGRESS" | "COMPLETED" | "FAILED";
+export type BetrayalStep = "RENOUNCE" | "PROVE" | "COMPLETE";
+
+export interface BetrayalQuest {
+  id: number;
+  character_id: number;
+  target_faction_id: number;
+  current_step: BetrayalStep;
+  status: BetrayalStatus;
+  started_at: Date;
+  updated_at: Date;
 }
 
 // Request/Response types for API

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,17 @@
+import { Response } from "express";
+
+export const sendError = (
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details?: Record<string, string[]>
+) => {
+  res.status(status).json({
+    error: {
+      code,
+      message,
+      details,
+    },
+  });
+};

--- a/src/utils/loot.ts
+++ b/src/utils/loot.ts
@@ -10,6 +10,13 @@ export interface LootSelection {
   quantity: number;
 }
 
+export interface InventoryStack {
+  item_code: string;
+  quantity: number;
+}
+
+export type DeathLootRule = "NONE" | "PARTIAL" | "FULL";
+
 export const createSeededRandom = (seed: number) => {
   let state = seed >>> 0;
   return () => {
@@ -50,4 +57,38 @@ export const selectWeightedLoot = (
     item_code: selected.item_code,
     quantity,
   };
+};
+
+export const calculateDeathDrops = (
+  inventory: InventoryStack[],
+  rule: DeathLootRule
+): { dropped: InventoryStack[]; remaining: InventoryStack[] } => {
+  if (rule === "NONE") {
+    return {
+      dropped: [],
+      remaining: inventory.map((stack) => ({ ...stack })),
+    };
+  }
+
+  const dropped: InventoryStack[] = [];
+  const remaining: InventoryStack[] = [];
+
+  for (const stack of inventory) {
+    if (rule === "FULL") {
+      dropped.push({ ...stack });
+      continue;
+    }
+
+    const dropQuantity = Math.floor(stack.quantity / 2);
+    const keepQuantity = stack.quantity - dropQuantity;
+
+    if (dropQuantity > 0) {
+      dropped.push({ item_code: stack.item_code, quantity: dropQuantity });
+    }
+    if (keepQuantity > 0) {
+      remaining.push({ item_code: stack.item_code, quantity: keepQuantity });
+    }
+  }
+
+  return { dropped, remaining };
 };

--- a/src/utils/securityLog.ts
+++ b/src/utils/securityLog.ts
@@ -1,0 +1,27 @@
+import { Request } from "express";
+
+export interface SuspiciousActionContext {
+  player_id?: number;
+  character_id?: number;
+  zone_id?: number;
+  action: string;
+  reason: string;
+}
+
+const getRequestIp = (req: Request) => {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    return forwarded.split(",")[0].trim();
+  }
+  if (Array.isArray(forwarded)) {
+    return forwarded[0];
+  }
+  return req.ip;
+};
+
+export const logSuspiciousAction = (req: Request, context: SuspiciousActionContext) => {
+  console.warn("Suspicious action", {
+    ...context,
+    ip: getRequestIp(req),
+  });
+};

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -53,21 +53,6 @@ describe("API Endpoints", () => {
     });
   });
 
-  describe("POST /api/characters", () => {
-    it("returns 500 when database is disabled", async () => {
-      const response = await request(app)
-        .post("/api/characters")
-        .send({
-          name: "TestCharacter",
-          faction_id: 1,
-          class_id: 1,
-        });
-
-      expect(response.status).toBe(500);
-      expect(response.body).toHaveProperty("error");
-    });
-  });
-
   describe("POST /api/auth/register", () => {
     it("returns 400 for invalid payload", async () => {
       const response = await request(app)
@@ -109,93 +94,75 @@ describe("API Endpoints", () => {
     });
   });
 
-  describe("POST /api/world/zone-enter", () => {
-    it("returns 400 for invalid payload", async () => {
+  describe("Protected routes", () => {
+    it("returns 401 for missing token on /api/characters", async () => {
+      const response = await request(app).get("/api/characters");
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 for missing token on /api/world/zone-enter", async () => {
       const response = await request(app)
         .post("/api/world/zone-enter")
         .send({
-          character_id: "bad",
-          zone_id: null,
+          character_id: 1,
+          zone_id: 1,
+          position: { x: 1, y: 1 },
         });
 
-      expect(response.status).toBe(400);
-      expect(response.body).toHaveProperty("error");
-      expect(response.body.error.code).toBe("INVALID_INPUT");
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
     });
-  });
 
-  describe("GET /api/world/state/:characterId", () => {
-    it("returns 400 for invalid character id", async () => {
-      const response = await request(app).get("/api/world/state/not-a-number");
+    it("returns 401 for missing token on /api/inventory", async () => {
+      const response = await request(app).get("/api/inventory/1");
 
-      expect(response.status).toBe(400);
-      expect(response.body).toHaveProperty("error");
-      expect(response.body.error.code).toBe("INVALID_INPUT");
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
     });
-  });
 
-  describe("GET /api/inventory/:characterId", () => {
-    it("returns 400 for invalid character id", async () => {
-      const response = await request(app).get("/api/inventory/not-a-number");
-
-      expect(response.status).toBe(400);
-      expect(response.body).toHaveProperty("error");
-      expect(response.body.error.code).toBe("INVALID_INPUT");
-    });
-  });
-
-  describe("POST /api/inventory/:characterId/add", () => {
-    it("returns 400 for invalid payload", async () => {
-      const response = await request(app)
-        .post("/api/inventory/1/add")
-        .send({
-          item_code: "",
-          quantity: -3,
-        });
-
-      expect(response.status).toBe(400);
-      expect(response.body).toHaveProperty("error");
-      expect(response.body.error.code).toBe("INVALID_INPUT");
-    });
-  });
-
-  describe("POST /api/inventory/:characterId/remove", () => {
-    it("returns 400 for invalid payload", async () => {
-      const response = await request(app)
-        .post("/api/inventory/1/remove")
-        .send({
-          item_code: "NOPE",
-          quantity: 0,
-        });
-
-      expect(response.status).toBe(400);
-      expect(response.body).toHaveProperty("error");
-      expect(response.body.error.code).toBe("INVALID_INPUT");
-    });
-  });
-
-  describe("GET /api/gathering/nodes/:zoneId", () => {
-    it("returns 400 for invalid zone id", async () => {
-      const response = await request(app).get("/api/gathering/nodes/not-a-number");
-
-      expect(response.status).toBe(400);
-      expect(response.body).toHaveProperty("error");
-      expect(response.body.error.code).toBe("INVALID_INPUT");
-    });
-  });
-
-  describe("POST /api/gathering/attempt", () => {
-    it("returns 400 for invalid payload", async () => {
+    it("returns 401 for missing token on /api/gathering/attempt", async () => {
       const response = await request(app)
         .post("/api/gathering/attempt")
         .send({
-          character_id: "bad",
-          node_code: "",
+          character_id: 1,
+          node_code: "COPPER_VEIN",
         });
 
-      expect(response.status).toBe(400);
-      expect(response.body).toHaveProperty("error");
-      expect(response.body.error.code).toBe("INVALID_INPUT");
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 for missing token on /api/combat/attack", async () => {
+      const response = await request(app)
+        .post("/api/combat/attack")
+        .send({
+          character_id: 1,
+          npc_id: 1,
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 for missing token on /api/loot/containers", async () => {
+      const response = await request(app).get("/api/loot/containers/1");
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 for missing token on /api/betrayal/start", async () => {
+      const response = await request(app)
+        .post("/api/betrayal/start")
+        .send({
+          character_id: 1,
+          target_faction_id: 2,
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("UNAUTHORIZED");
     });
   });
 });

--- a/tests/loot.test.ts
+++ b/tests/loot.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { calculateDeathDrops } from "../src/utils/loot";
+
+describe("calculateDeathDrops", () => {
+  it("returns no drops for NONE rule", () => {
+    const result = calculateDeathDrops([
+      { item_code: "IRON_ORE", quantity: 5 },
+    ], "NONE");
+
+    expect(result.dropped).toEqual([]);
+    expect(result.remaining).toEqual([{ item_code: "IRON_ORE", quantity: 5 }]);
+  });
+
+  it("drops half of each stack for PARTIAL rule", () => {
+    const result = calculateDeathDrops([
+      { item_code: "IRON_ORE", quantity: 5 },
+      { item_code: "COPPER_ORE", quantity: 2 },
+    ], "PARTIAL");
+
+    expect(result.dropped).toEqual([
+      { item_code: "IRON_ORE", quantity: 2 },
+      { item_code: "COPPER_ORE", quantity: 1 },
+    ]);
+    expect(result.remaining).toEqual([
+      { item_code: "IRON_ORE", quantity: 3 },
+      { item_code: "COPPER_ORE", quantity: 1 },
+    ]);
+  });
+
+  it("drops everything for FULL rule", () => {
+    const result = calculateDeathDrops([
+      { item_code: "IRON_ORE", quantity: 5 },
+    ], "FULL");
+
+    expect(result.dropped).toEqual([{ item_code: "IRON_ORE", quantity: 5 }]);
+    expect(result.remaining).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a lightweight Unity renderer so the vertical slice can be played in an engine with simple animation and runtime UI.
- Give designers a browser-based Playtest Console for exercising server flows without a Unity build by serving `public/*` assets.
- Enforce server-authoritative gameplay rules (ownership, zone, range, cooldowns) and deterministic death/loot math so tests are reproducible.
- Seed DB schema and a minimal NPC (training dummy) to enable immediate PvE playtesting.

### Description
- Added a Unity playtest client under `client/unity` including `ApiClient.cs`, `Models.cs`, `PlaytestBootstrap.cs`, a `SimpleAnimator`, project scaffolding, and `client/unity/README.md`.
- Added a browser Playtest Console (`public/index.html`, `public/app.js`, `public/styles.css`) and serve it from the server via `app.use(express.static(...))` in `src/app.ts`.
- Implemented server-side middleware and utilities (`src/middleware/auth.ts`, `src/utils/errors.ts`, `src/utils/securityLog.ts`, `src/utils/loot.ts`) and wired server-authoritative routes for `combat`, `loot`, `betrayal`, and `reputation` while hardening `characters`, `inventory`, `gathering`, and `world` routes to validate ownership and ranges.
- Added DB migrations (`migrations/013_*`..`017_*`) to seed players, `character_state`, NPC templates/spawns, loot containers, and reputation/betrayal tables, and updated docs/README to document the client and Playtest Console.

### Testing
- Added unit tests `tests/loot.test.ts` for `calculateDeathDrops` (behavior: `NONE`/`PARTIAL`/`FULL`) but they were not executed in this rollout.
- Updated `tests/api.test.ts` to assert authentication gating on protected endpoints, but the test suite was not run here.
- No CI run or `npm test` was executed during this change, so automated tests remain unverified in this commit.
- The new tests are included for CI/local runs and should be executed in follow-up CI verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db61cc5c083249724f601e36119fd)